### PR TITLE
Run GlusterFS in the default namespace

### DIFF
--- a/stacks/gluster-storage/roles/gluster-server/files/gluster-daemonset.yml
+++ b/stacks/gluster-storage/roles/gluster-server/files/gluster-daemonset.yml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: gluster-server
-  namespace: gluster
+  namespace: default
   labels:
     k8s-app: gluster-server
     kubernetes.io/cluster-service: "true"
@@ -56,7 +56,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gluster-server
-  namespace: gluster
+  namespace: default
 spec:
   selector:
     k8s-app: gluster-server

--- a/stacks/gluster-storage/roles/gluster-server/files/gluster-namespace.yml
+++ b/stacks/gluster-storage/roles/gluster-server/files/gluster-namespace.yml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: gluster

--- a/stacks/gluster-storage/roles/gluster-server/tasks/main.yml
+++ b/stacks/gluster-storage/roles/gluster-server/tasks/main.yml
@@ -6,22 +6,11 @@
     state: directory
     mode: 0755
 
-- name: copy gluster Namespace configuration
-  become: yes
-  copy:
-    src: gluster-namespace.yml
-    dest: "/etc/kubenow/yaml/gluster-namespace.yml"
-
 - name: copy gluster DaemonSet configuration
   become: yes
   copy:
     src: gluster-daemonset.yml
     dest: "/etc/kubenow/yaml/gluster-daemonset.yml"
-
-- name: create gluster Namespace
-  command: >
-    kubectl apply -f
-    /etc/kubenow/yaml/gluster-namespace.yml
 
 - name: start gluster DaemonSet
   command: >
@@ -31,8 +20,7 @@
 - name: wait for gluster DaemonSet to be Running
   command: >
     kubectl get pods
-    -o jsonpath='{.items[*].status.phase}'
-    --namespace=gluster
+    -o jsonpath='{.items[?(@.spec.containers[*].name=="gluster-server")].status.phase}'
   register: get_phase
   until: get_phase.stdout | match('^(Running\s)*Running$')
   # Wait for 10 minutes
@@ -40,17 +28,16 @@
   delay: 5
 
 - name: retrieve gluster-server pod name
-  command: >
+  shell: >
     kubectl get pods
-    -o jsonpath='{.items[0].metadata.name}'
-    --namespace=gluster
+    -o jsonpath='{.items[?(@.spec.containers[*].name=="gluster-server")].metadata.name}' |
+    awk '{print $1;}' | tr -d '\n'
   register: get_name
 
 - name: retrieve gluster-server IPs
   command: >
     kubectl get pods
-    -o jsonpath='{.items[*].status.podIP}'
-    --namespace=gluster
+    -o jsonpath='{.items[?(@.spec.containers[*].name=="gluster-server")].status.podIP}'
   register: get_ips
 
 - set_fact:
@@ -58,7 +45,7 @@
 
 - name: "gluster peer probe (gluster_side)"
   command: >
-    kubectl exec --namespace gluster {{get_name.stdout}}
+    kubectl exec {{get_name.stdout}}
     gluster peer probe {{item}}
   with_items: "{{enpoint_list}}"
   tags:

--- a/stacks/gluster-storage/roles/shared-volume/tasks/main.yml
+++ b/stacks/gluster-storage/roles/shared-volume/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: create shared-volume (gluster side)
   command: >
-    kubectl exec --namespace gluster {{get_name.stdout}}
+    kubectl exec {{get_name.stdout}}
     gluster volume create shared-volume
     replica 3 {{gluster_bricks | replace('\n', '')}}
     force
@@ -20,14 +20,14 @@
 
 - name: start shared-volume (gluster side)
   command: >
-    kubectl exec --namespace gluster {{get_name.stdout}}
+    kubectl exec {{get_name.stdout}}
     gluster volume start shared-volume
   tags:
     - gluster_side
 
 - name: get shared-volume cumulative size
   shell: >
-    kubectl exec --namespace gluster {{get_name.stdout}}
+    kubectl exec {{get_name.stdout}}
     gluster volume status shared-volume detail |
     grep 'Disk Space Free' |
     grep -o '[0-9]*\.[0-9]*' |


### PR DESCRIPTION
Run GlusterFS in the default namespace, otherwise the endpoints are hidden.