### PR TITLE
Feature/upgrade helm version

### DIFF
--- a/packer/requirements.sh
+++ b/packer/requirements.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y \
   glusterfs-client
 
 # Helm
-HELM_TGZ=helm-v2.0.0-linux-amd64.tar.gz
+HELM_TGZ=helm-v2.1.0-linux-amd64.tar.gz
 wget -P /tmp/ https://kubernetes-helm.storage.googleapis.com/$HELM_TGZ
 tar -xf /tmp/$HELM_TGZ -C /tmp/
 sudo mv /tmp/linux-amd64/helm /usr/local/bin/


### PR DESCRIPTION
Unfortunately there is no automatic compatible Helm version following the ubuntu apt-repo. In packer we are always pulling lates stable from kubernetes apt-rep