### PR TITLE
Read edge and node count from environment variables when terraform.tfvars is not available

### DIFF
--- a/playbooks/roles/wait-nodes/tasks/main.yml
+++ b/playbooks/roles/wait-nodes/tasks/main.yml
@@ -10,6 +10,8 @@
   args:
     chdir: "{{playbook_dir}}/.."
   register: get_nodes_count
+  when:
+    - get_nodes_count is undefined
 
 - name: "wait for all nodes to join the master"
   shell: >


### PR DESCRIPTION
hardcoded terraform.tfstate to "{{playbook_dir}}/.." is not working well for cloud-deployment where I put terraform.tfstate in a special working-directory per user