### PR TITLE
Improve CI and read the docs builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/secrets-kubenow"]
-	path = test/secrets-kubenow
-	url = git@github.com:mcapuccini/secrets-kubenow.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ branches:
     - /^docs\/.*$/
     - /^documentation\/.*$/
 
+env:
+  - HOST_CLOUD=openstack
+  - HOST_CLOUD=gce
+  - HOST_CLOUD=aws
+
 before_install:
   # Decrypt secrets
   - >
@@ -81,6 +86,4 @@ install:
   - source test/secrets-kubenow/host_cloud/aws.sh
 
 script:
-  - ansible-playbook -e "host_cloud=openstack" test/integration-test.yml
-  - ansible-playbook -e "host_cloud=gce" test/integration-test.yml
-  - ansible-playbook -e "host_cloud=aws" test/integration-test.yml
+  - ansible-playbook -e "host_cloud=$HOST_CLOUD" test/integration-test.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,6 @@ install:
   - source test/secrets-kubenow/host_cloud/aws.sh
 
 script:
-  - travis_wait ansible-playbook -e "host_cloud=openstack" test/integration-test.yml
-  - travis_wait ansible-playbook -e "host_cloud=gce" test/integration-test.yml
-  - travis_wait ansible-playbook -e "host_cloud=aws" test/integration-test.yml
+  - ansible-playbook -e "host_cloud=openstack" test/integration-test.yml
+  - ansible-playbook -e "host_cloud=gce" test/integration-test.yml
+  - ansible-playbook -e "host_cloud=aws" test/integration-test.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   # Add the keypair to the agent
   - eval "$(ssh-agent -s)"
   - ssh-add test/secret/kubenow-ci
-  # Get submodules
+  # Get secrets
   - git clone git@github.com:mcapuccini/secrets-kubenow.git test/secrets-kubenow
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python # (Ansible)
 
 sudo: required
 
-git:
-  # Disable default submodule logic
-  submodules: false
-
 branches:
   except:
     - /^experimental\/.*$/
@@ -33,7 +29,7 @@ before_install:
   - eval "$(ssh-agent -s)"
   - ssh-add test/secret/kubenow-ci
   # Get submodules
-  - git submodule update --init --recursive
+  - git clone git@github.com:mcapuccini/secrets-kubenow.git test/secrets-kubenow
 
 install:
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 secret
 secret.tgz
+secrets-kubenow

--- a/test/roles/test-packer/tasks/main.yml
+++ b/test/roles/test-packer/tasks/main.yml
@@ -12,6 +12,17 @@
   args:
     chdir: "{{playbook_dir}}/.."
   notify: "delete image"
+  # run asynch (travis needs some polling output)
+  async: 1800 # 30 minutes
+  poll: 0
+  register: packer_build
+
+- name: "wait for packer image to be ready"
+  async_status: jid={{ packer_build.ansible_job_id }}
+  register: build_result
+  until: build_result.finished
+  retries: 30
+  delay: 60
 
 - include: get_ami_facts.yml
   when: host_cloud == "aws"

--- a/test/roles/test-packer/tasks/main.yml
+++ b/test/roles/test-packer/tasks/main.yml
@@ -11,7 +11,6 @@
     packer/build-{{host_cloud}}.json
   args:
     chdir: "{{playbook_dir}}/.."
-  notify: "delete image"
   # run asynch (travis needs some polling output)
   async: 1800 # 30 minutes
   poll: 0
@@ -20,6 +19,8 @@
 - name: "wait for packer image to be ready"
   async_status: jid={{ packer_build.ansible_job_id }}
   register: build_result
+  notify: "delete image"
+  # loop until build finishes
   until: build_result.finished
   retries: 30
   delay: 60


### PR DESCRIPTION
- Remove secrets submodule, it breaks Read The Docs build.
- Remove travis_wait and use Ansible asynch instead (more robust)
- Split the build in a job for each host cloud