### PR TITLE
Added optional possibility to config dns servers on openstack

### DIFF
--- a/docs/getting_started/bootstrap.rst
+++ b/docs/getting_started/bootstrap.rst
@@ -69,6 +69,7 @@ Start by creating a ``terraform.tfvars`` file. There is a template that you can 
 - **ssh_key**: path to your public ssh-key to be used (for ssh node access)
 - **floating_ip_pool**: a floating IP pool name
 - **external_network_uuid**: the uuid of the external network in the OpenStack tenancy
+- **dns_nameservers**: (optional, only needed if you want to use other dns-servers than default 8.8.8.8 and 8.8.4.4)
 - **kubeadm_token**: a token that will be used by kubeadm, to bootstrap Kubernetes. You can run generate_kubetoken.sh to create a valid one.
 
 **Master configuration**

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -3,6 +3,7 @@ variable cluster_prefix {}
 variable KuberNow_image {}
 variable ssh_key {}
 variable external_network_uuid {}
+variable dns_nameservers { default="8.8.8.8,8.8.4.4" }
 variable floating_ip_pool {}
 variable kubeadm_token {}
 
@@ -32,6 +33,7 @@ module "network" {
   source = "./network"
   external_net_uuid = "${var.external_network_uuid}"
   name_prefix = "${var.cluster_prefix}"
+  dns_nameservers = "${var.dns_nameservers}"
 }
 
 module "master" {

--- a/openstack/network/main.tf
+++ b/openstack/network/main.tf
@@ -1,7 +1,7 @@
 variable name_prefix {}
 variable subnet_cidr { default = "10.0.0.0/16"}
 variable external_net_uuid {}
-variable dns_nameservers { default="8.8.8.8,8.8.4.4" }
+variable dns_nameservers {}
 
 resource "openstack_networking_network_v2" "main" {
   name = "${var.name_prefix}-network"


### PR DESCRIPTION
fixes issue #81
Tested on CityCloud and Embassy, On citycloud an empty parameter "" makes nodes /etc/resolv.conf use citycloud pre-configured dns, on embassy not specifying dns makes nodes not reach internet and leaves /etc/resolv.conf empty. I choosed to make google dns default, and OpenStack configured dns optional (by specifying dns_nameservers = "")