### PR TITLE
Fix illegal var - terraform 0.8

### DIFF
--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -36,7 +36,7 @@ resource "aws_route_table" "main" {
   }
 
   tags {
-    Name = "${name_prefix}"
+    Name = "${var.name_prefix}"
   }
 }
 


### PR DESCRIPTION
Fix a bug due to wrong syntax that has sneaked through in previous versions of terraform