### PR TITLE
Feature/prepare for vagrant

### DIFF
--- a/bootstrap/master.sh
+++ b/bootstrap/master.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status
-set -e
-
 echo "Inititializing the master..."
-kubeadm init --token ${kubeadm_token}
+
+if [ -n "$api_advertise_addresses" ]
+then
+    kubeadm init --token ${kubeadm_token} --api-advertise-addresses=$api_advertise_addresses
+else
+    kubeadm init --token ${kubeadm_token}
+fi

--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -4,7 +4,7 @@
     host={{ ansible_ssh_host | default(inventory_hostname) }}
     port={{ ansible_port | default(22) }}
     search_regex=OpenSSH
-    delay=5
+    delay=10
     timeout=300
 
 - name: "render node count"

--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -2,9 +2,9 @@
 - name: "wait for server to respond on ssh port"
   local_action: wait_for
     host={{ ansible_ssh_host | default(inventory_hostname) }}
-    port=22
+    port={{ ansible_port | default(22) }}
     search_regex=OpenSSH
-    delay=10
+    delay=5
     timeout=300
 
 - name: "render node count"


### PR DESCRIPTION
These small changes are all changes needed in the current KubeNow codebase for Local Vagrant version of KubeNow, if these are included in master we don't have to switch KubeNow subrepo version when doing a one-click deployment from phnmnl/cloud-deploy-kubenow repo