### PR TITLE
Fixes infra-test fail on single edge node

### DIFF
--- a/playbooks/roles/common-test/tasks/main.yml
+++ b/playbooks/roles/common-test/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: "get edge labels"
   command: >
     kubectl get nodes {{ edge_names }}
-    -o jsonpath='{@.items[*].metadata.labels.role}'
+    -o jsonpath='{@..metadata.labels.role}'
   register: get_edge_roles
 
 - name: "test edge labels"


### PR DESCRIPTION
This fix will look for anything that ends with .metadata.labels.role no matter if it is in an array or not.