### PR TITLE
Add all public keys from public_keys folder to authorized_keys in master

### DIFF
--- a/openstack/master/main.tf
+++ b/openstack/master/main.tf
@@ -49,6 +49,18 @@ resource "null_resource" "generate-inventory" {
 
 }
 
+# Upload all additional public keys to master node
+resource "null_resource" "upload_public_keys" {
+  provisioner "local-exec" {
+    command = "for key in ${path.cwd}/public_keys/*; do (cat $key;echo) | ssh -oStrictHostKeyChecking=no ubuntu@${openstack_compute_floatingip_v2.master_ip.0.address} 'cat >> .ssh/authorized_keys'; done"
+  	
+  	connection = {
+	  type = "ssh"
+	  timeout = "15m"
+  	}
+  }
+}
+
 output "ip_address" {
   value = "${openstack_compute_instance_v2.master.0.network.0.fixed_ip_v4}"
 }


### PR DESCRIPTION
This feature enables a user to add a directory called 

> public_keys

In the KubeNow root directory and simply put desired public keys into it and they will be added into the authorized_keys of the master node. Should work for any number of keys and 'fails' gracefully by outputting only that there is no such files:

> module.master.null_resource.upload_public_keys (local-exec): cat: [path to KubeNow]/public_keys/*: No such file or directory

