### PR TITLE
Added Ansible playbook for uploading multiple keys to authorized_keys…

### DIFF
--- a/playbooks/upload-keys.yml
+++ b/playbooks/upload-keys.yml
@@ -6,4 +6,4 @@
         state: present
         key: "{{ lookup('file', item) }}"
       with_fileglob:
-        - '{{playbook_dir}}/../public_keys/*.pub'
+        - "{{ (public_keys_dir | default(playbook_dir ~ '/../public_keys' )) ~ '/*.pub' }}"

--- a/playbooks/upload-keys.yml
+++ b/playbooks/upload-keys.yml
@@ -1,0 +1,9 @@
+- hosts: master
+  tasks:
+    - name: Set up multiple authorized keys
+      authorized_key:
+        user: ubuntu
+        state: present
+        key: "{{ lookup('file', item) }}"
+      with_fileglob:
+        - '{{playbook_dir}}/../public_keys/*.pub'

--- a/public_keys/README.md
+++ b/public_keys/README.md
@@ -1,0 +1,6 @@
+# Public Keys Directory
+
+This directory can be used for dropping in the public keys of all developers/users that you wish to have access to your Kubernetes cluster. Then run the ansible playbook **upload-keys** by: `ansible-playbook playbooks/upload-keys.yml`. If you do not wish to put the public keys within the KubeNow directory you can still use the playbook by specifying your own directory by setting the variable **public_keys_dir** and run it using: `ansible-playbook playbooks/upload-keys.yml --extra-vars "public_keys_dir=/your/ssh/directory/"`.
+
+**Note** All public key files must have the file ending **.pub**, other files in this directory will be ignored. 
+


### PR DESCRIPTION
… for the master

This playbook will add keys from the directory: 

> [KubeNowDir]/public_keys/ 

Into the masters Aurthorized_keys. Another possibility is to make this as the default and make it possible to give a user-defined directory as a parameter. 