### PR TITLE
Feature/taints and labels as list

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -101,8 +101,8 @@ module "master" {
   # Bootstrap settings
   bootstrap_file = "bootstrap/master.sh"
   kubeadm_token = "${var.kubeadm_token}"
-  node_labels = ""
-  node_taints = ""
+  node_labels = [""]
+  node_taints = [""]
   master_ip = ""
 }
 
@@ -126,8 +126,8 @@ module "node" {
   # Bootstrap settings
   bootstrap_file = "bootstrap/node.sh"
   kubeadm_token = "${var.kubeadm_token}"
-  node_labels = "role=node"
-  node_taints = ""
+  node_labels = ["role=node"]
+  node_taints = [""]
   master_ip = "${element(module.master.local_ip_v4, 0)}"
 }
 
@@ -151,8 +151,8 @@ module "edge" {
   # Bootstrap settings
   bootstrap_file = "bootstrap/node.sh"
   kubeadm_token = "${var.kubeadm_token}"
-  node_labels = "role=edge"
-  node_taints = ""
+  node_labels = ["role=edge"]
+  node_taints = [""]
   master_ip = "${element(module.master.local_ip_v4, 0)}"
 }
 

--- a/aws/node/main.tf
+++ b/aws/node/main.tf
@@ -22,8 +22,8 @@ variable extra_disk_type { default = "gp2" }
 # Bootstrap settings
 variable bootstrap_file {}
 variable kubeadm_token {}
-variable node_labels {}
-variable node_taints {}
+variable node_labels { type = "list" }
+variable node_taints { type = "list" }
 variable master_ip { default="" }
 
 # Bootstrap
@@ -32,8 +32,8 @@ data "template_file" "instance_bootstrap" {
   vars {
     kubeadm_token = "${var.kubeadm_token}"
     master_ip = "${var.master_ip}"
-    node_labels = "${var.node_labels}"
-    node_taints = "${var.node_taints}"
+    node_labels = "${join(",", var.node_labels)}"
+    node_taints = "${join(",", var.node_taints)}"
   }
 }
 

--- a/gce/main.tf
+++ b/gce/main.tf
@@ -55,8 +55,8 @@ module "master" {
   # Bootstrap settings
   bootstrap_file = "bootstrap/master.sh"
   kubeadm_token = "${var.kubeadm_token}"
-  node_labels = ""
-  node_taints = ""
+  node_labels = [""]
+  node_taints = [""]
   master_ip = ""
 }
 
@@ -78,8 +78,8 @@ module "node" {
   # Bootstrap settings
   bootstrap_file = "bootstrap/node.sh"
   kubeadm_token = "${var.kubeadm_token}"
-  node_labels = "role=node"
-  node_taints = ""
+  node_labels = ["role=node"]
+  node_taints = [""]
   master_ip = "${element(module.master.local_ip_v4, 0)}"
 }
 
@@ -101,8 +101,8 @@ module "edge" {
   # Bootstrap settings
   bootstrap_file = "bootstrap/node.sh"
   kubeadm_token = "${var.kubeadm_token}"
-  node_labels = "role=edge"
-  node_taints = ""
+  node_labels = ["role=edge"]
+  node_taints = [""]
   master_ip = "${element(module.master.local_ip_v4, 0)}"
 }
 

--- a/gce/node/main.tf
+++ b/gce/node/main.tf
@@ -18,8 +18,8 @@ variable disk_size {}
 # Bootstrap settings
 variable bootstrap_file {}
 variable kubeadm_token {}
-variable node_labels {}
-variable node_taints {}
+variable node_labels { type = "list" }
+variable node_taints { type = "list" }
 variable master_ip { default="" }
 
 # Bootstrap
@@ -28,8 +28,8 @@ data "template_file" "instance_bootstrap" {
   vars {
     kubeadm_token = "${var.kubeadm_token}"
     master_ip     = "${var.master_ip}"
-    node_labels   = "${var.node_labels}"
-    node_taints   = "${var.node_taints}"
+    node_labels = "${join(",", var.node_labels)}"
+    node_taints = "${join(",", var.node_taints)}"
   }
 }
 

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -57,8 +57,8 @@ module "master" {
   # Bootstrap settings
   bootstrap_file = "bootstrap/master.sh"
   kubeadm_token = "${var.kubeadm_token}"
-  node_labels = ""
-  node_taints = ""
+  node_labels = [""]
+  node_taints = [""]
   master_ip = ""
 }
 
@@ -82,29 +82,33 @@ module "node" {
   # Bootstrap settings
   bootstrap_file = "bootstrap/node.sh"
   kubeadm_token = "${var.kubeadm_token}"
-  node_labels = "role=node"
-  node_taints = ""
+  node_labels = ["role=node"]
+  node_taints = [""]
   master_ip = "${element(module.master.local_ip_v4, 0)}"
 }
 
 module "edge" {
-  node_labels = "role=edge"
-  node_taints = ""
-  extra_disk_size = "0"
-
+  # Core settings
   source = "./node"
-  name_prefix = "${var.cluster_prefix}-edge"
   count = "${var.edge_count}"
+  name_prefix = "${var.cluster_prefix}-edge"
   flavor_name = "${var.edge_flavor}"
   flavor_id = "${var.edge_flavor_id}"
-  assign_floating_ip = "true"
-  floating_ip_pool = "${var.floating_ip_pool}"
   image_name = "${var.kubenow_image}"
+  # SSH settings
   keypair_name = "${module.keypair.keypair_name}"
+  # Network settings
   network_name = "${module.network.network_name}"
   secgroup_name = "${module.network.secgroup_name}"
-  kubeadm_token = "${var.kubeadm_token}"
+  assign_floating_ip = "true"
+  floating_ip_pool = "${var.floating_ip_pool}"
+   # Disk settings
+  extra_disk_size = "0"
+  # Bootstrap settings
   bootstrap_file = "bootstrap/node.sh"
+  kubeadm_token = "${var.kubeadm_token}"
+  node_labels = ["role=edge"]
+  node_taints = [""]
   master_ip = "${element(module.master.local_ip_v4, 0)}"
 }
 

--- a/openstack/node/main.tf
+++ b/openstack/node/main.tf
@@ -20,8 +20,8 @@ variable extra_disk_size { default=0 }
 # Bootstrap settings
 variable bootstrap_file {}
 variable kubeadm_token {}
-variable node_labels {}
-variable node_taints {}
+variable node_labels { type = "list" }
+variable node_taints { type = "list" }
 variable master_ip { default="" }
 
 # Bootstrap
@@ -30,8 +30,8 @@ data "template_file" "instance_bootstrap" {
   vars {
     kubeadm_token = "${var.kubeadm_token}"
     master_ip = "${var.master_ip}"
-    node_labels = "${var.node_labels}"
-    node_taints = "${var.node_taints}"
+    node_labels = "${join(",", var.node_labels)}"
+    node_taints = "${join(",", var.node_taints)}"
   }
 }
 


### PR DESCRIPTION
This change is mainly because terraform doesn't support searching if a string contains a substring, whereas it is possible to look for an element in a list. Useful for implementation of Cloudflare terraform module, and allowing master to have an edge role