### PR TITLE
Add travis_retry for terraform apply/destroy in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,10 +95,10 @@ script:
         playbooks/import-"$HOST_CLOUD"-image.yml
       fi
   - terraform get $HOST_CLOUD
-  - terraform apply $HOST_CLOUD
+  - travis_retry terraform apply $HOST_CLOUD
   - ansible-playbook playbooks/install-core.yml
   - ansible-playbook playbooks/infra-test.yml
 
 after_script:
-  - terraform destroy -force $HOST_CLOUD
+  - travis_retry terraform destroy -force $HOST_CLOUD
   - ansible-playbook playbooks/clean-cloudflare.yml


### PR DESCRIPTION
## Change content and motivation
Sometimes CI fails due to timeouts. This change will retry terraform apply/destroy 3 times before to give up.

## GitHub cross-links 
**Fixes:** fixes #168 
