### PR TITLE
Add tests for tfvars templates in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_script:
         cp terraform.tfvars.${HOST_CLOUD}-template terraform.tfvars
       fi
   - mkdir -p ~/.ssh/ && cp test/secret/kubenow-ci.pub ~/.ssh/id_rsa.pub
-  - sed -i -e "s/your-cluster-prefix/$kubenow-ci-${TRAVIS_BUILD_NUMBER}/g" terraform.tfvars
+  - sed -i -e "s/your-cluster-prefix/kubenow-ci-${TRAVIS_BUILD_NUMBER}/g" terraform.tfvars
   - sed -i -e "s/your-kubeadm-token/${CI_KUBETOKEN}/g" terraform.tfvars
   # AWS
   - sed -i -e "s/your-acces-key-id/${AWS_ACCESS_KEY_ID}/g" terraform.tfvars

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ before_script:
   - sed -i -e "s/your-kubeadm-token/${CI_KUBETOKEN}/g" terraform.tfvars
   # AWS
   - sed -i -e "s/your-acces-key-id/${AWS_ACCESS_KEY_ID}/g" terraform.tfvars
-  - sed -i -e "s/your-secret-access-key/${AWS_SECRET_ACCESS_KEY}/g" terraform.tfvars
+  - sed -i -e "s/your-secret-access-key/${AWS_SECRET_ACCESS_KEY_SED}/g" terraform.tfvars
   # GCE
   - cp test/secrets-kubenow/host_cloud/gce-key.json ~/account_file.json
   - sed -i -e "s/your_project_id/${GCE_PROJECT_ID}/g" terraform.tfvars

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,13 +73,34 @@ install:
 before_script:
 
   # Source test environment
+  - source test/secrets-kubenow/host_cloud/common.sh
   - source test/secrets-kubenow/host_cloud/CityCloud.sh
   - source test/secrets-kubenow/host_cloud/aws.sh
+  - source test/secrets-kubenow/host_cloud/gce.sh
 
   # Render Terraform configuration
+  # Common
   - >
-      env | j2 --format=env test/secrets-kubenow/tfvars/"$HOST_CLOUD".tfvars.j2 >
-      ./terraform.tfvars
+      if [ $HOST_CLOUD = 'openstack' ]; then
+        cp terraform.tfvars.os-template terraform.tfvars
+      else
+        cp terraform.tfvars.${HOST_CLOUD}-template terraform.tfvars
+      fi
+  - mkdir -p ~/.ssh/ && cp test/secret/kubenow-ci.pub ~/.ssh/id_rsa.pub
+  - sed -i -e "s/your-cluster-prefix/$kubenow-ci-${TRAVIS_BUILD_NUMBER}/g" terraform.tfvars
+  - sed -i -e "s/your-kubeadm-token/${CI_KUBETOKEN}/g" terraform.tfvars
+  # AWS
+  - sed -i -e "s/your-acces-key-id/${AWS_ACCESS_KEY_ID}/g" terraform.tfvars
+  - sed -i -e "s/your-secret-access-key/${AWS_SECRET_ACCESS_KEY}/g" terraform.tfvars
+  # GCE
+  - cp test/secrets-kubenow/host_cloud/gce-key.json ~/account_file.json
+  - sed -i -e "s/your_project_id/${GCE_PROJECT_ID}/g" terraform.tfvars
+  # OS
+  - sed -i -e "s/your-pool-name/${OS_POOL_NAME}/g" terraform.tfvars
+  - sed -i -e "s/external-net-uuid/${OS_EXTERNAL_NET_UUUID}/g" terraform.tfvars
+  - sed -i -e "s/your-master-flavor/${OS_MASTER_FLAVOR}/g" terraform.tfvars
+  - sed -i -e "s/your-node-flavor/${OS_NODE_FLAVOR}/g" terraform.tfvars
+  - sed -i -e "s/your-edge-flavor/${OS_EDGE_FLAVOR}/g" terraform.tfvars
 
   # Render Cloudflare configuration
   - >

--- a/terraform.tfvars.aws-template
+++ b/terraform.tfvars.aws-template
@@ -1,5 +1,5 @@
 # Cluster configuration
-cluster_prefix = "kubenow" # Your cluster prefix
+cluster_prefix = "your-cluster-prefix" # Your cluster prefix
 kubenow_image = "kubenow-v020" # Name of the image created with Packer
 kubeadm_token = "your-kubeadm-token" # You can run generate_kubetoken.sh to create a valid token
 ssh_key = "~/.ssh/id_rsa.pub" # Path to your public SSH key (for ssh node access)

--- a/terraform.tfvars.gce-template
+++ b/terraform.tfvars.gce-template
@@ -1,25 +1,25 @@
 # Cluster configuration
-cluster_prefix = "kubenow" # Your cluster prefix
+cluster_prefix = "your-cluster-prefix" # Your cluster prefix
 kubenow_image = "kubenow-v020" # Name of the image created with Packer
 kubeadm_token = "your-kubeadm-token" # You can run generate_kubetoken.sh to create a valid token
 ssh_key = "~/.ssh/id_rsa.pub" # Path to your public SSH key (for ssh node access)
 
 # Google credetials
-gce_credentials_file = "/home/my/account_file.json" # Path to your Google service account file
+gce_credentials_file = "~/account_file.json" # Path to your Google service account file
 gce_project = "your_project_id" # Google project id
 gce_zone = "europe-west1-b" # Some GCE zone
 
 # Master configuration
 # obs: too small flavors might cause diffuse errors on your installation
-master_flavor = "n1-standard-1"
+master_flavor = "n1-standard-2"
 master_disk_size = "20" # Size in GB
 
 # Node configuration
 node_count = "3"
-node_flavor = "n1-standard-1"
+node_flavor = "n1-standard-2"
 node_disk_size = "20" # Size in GB
 
 # Edge configuration
 edge_count = "2"
-edge_flavor = "n1-standard-1"
+edge_flavor = "n1-standard-2"
 edge_disk_size = "20" # Size in GB

--- a/terraform.tfvars.os-template
+++ b/terraform.tfvars.os-template
@@ -1,5 +1,5 @@
 # Cluster configuration
-cluster_prefix = "kubenow" # Your cluster prefix
+cluster_prefix = "your-cluster-prefix" # Your cluster prefix
 kubenow_image = "kubenow-v020" # Name of the image created with Packer
 ssh_key = "~/.ssh/id_rsa.pub" # Path to your public SSH key to be used for ssh node access
 kubeadm_token = "your-kubeadm-token" # You can run generate_kubetoken.sh to create a valid token


### PR DESCRIPTION
## Change content and motivation
This adds a test to the CI that renders the tfvars templates, instead of using predefined configuration in the secret repo. This will make sure that the templates are in synch with the terraform modules.

## GitHub cross-links 
**Fixes:** fixes #167 
