### PR TITLE
Remove AMI ID var from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
     - TERRAFORM_VERSION=0.9.4
     - ANSIBLE_VERSION=2.2.0.0
     - IMAGE_VERSION=v020
-    - AWS_AMI_ID=ami-30251456
   matrix:
     - HOST_CLOUD=openstack
     - HOST_CLOUD=gce


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
Remove AWS_AMI_ID variable from Travis CI, it's no longer needed.