### PR TITLE
Shorten delay on wait_for ssh-ready on nodes

### DIFF
--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -4,7 +4,7 @@
     host={{ ansible_ssh_host | default(inventory_hostname) }}
     port={{ ansible_port | default(22) }}
     search_regex=OpenSSH
-    delay=10
+    delay=5
     timeout=300
 
 - name: "render node count"


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
The current 10 sek delay waiting for nodes to respond is boringly long
Deployment feels much more responsive with a 5 sek delay.
I don't thing the reduction from 10 to 5 sek will cause any negative side effects - 10 seconds is just chosen arbitrarily and if a reduction from 10 to 5 would case negative effects then the wait cycle is very shaky anyway:-)

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
