### PR TITLE
Split CI descriptor in smaller scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,12 @@ env:
   global:
     - TERRAFORM_VERSION=0.9.4
     - ANSIBLE_VERSION=2.2.0.0
-    - IMAGE_VERSION=v020
     - LIBCLOUD_VERSION=1.5.0
     - ANSIBLE_LINT_VERSION=3.4.13
   matrix:
     - HOST_CLOUD=openstack
     - HOST_CLOUD=gce
     - HOST_CLOUD=aws
-
-git:
-  submodules: false
 
 addons:
   apt:
@@ -36,95 +32,12 @@ addons:
     packages:
       - shellcheck
 
-before_install:
+before_install: ci/before_install.sh
 
-  # Generate keypair
-  - mkdir -p keypair
-  - ssh-keygen -q -t rsa -N "" -f keypair/kubenow-ci
+install: ci/install.sh
 
-  # Add the keypair to the agent
-  - eval "$(ssh-agent -s)"
-  - ssh-add keypair/kubenow-ci
+before_script: ci/before_script.sh
 
-install:
+script: script.sh
 
-  # Install Terraform
-  - >
-      travis_retry curl
-      "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-      > /tmp/terraform.zip
-  - sudo unzip /tmp/terraform.zip -d /usr/bin
-  - sudo chmod +x /usr/bin/terraform
-
-  # Install Ansible and pip deps
-  - sudo pip install --upgrade pip
-  - >
-      sudo pip install
-      ansible=="${ANSIBLE_VERSION}"
-      j2cli
-      dnspython
-      jmespath
-      backports.ssl_match_hostname
-      apache-libcloud=="${LIBCLOUD_VERSION}"
-      shade
-      ansible-lint=="${ANSIBLE_LINT_VERSION}"
-
-before_script:
-
-  # Render Terraform configuration
-  # Common
-  - >
-      if [ "$HOST_CLOUD" = 'openstack' ]; then
-        cp terraform.tfvars.os-template terraform.tfvars
-      else
-        cp "terraform.tfvars.${HOST_CLOUD}-template" terraform.tfvars
-      fi
-  - mkdir -p "$HOME/.ssh/" && cp keypair/kubenow-ci.pub "$HOME/.ssh/id_rsa.pub"
-  - sed -i -e "s/your-cluster-prefix/kubenow-ci-${TRAVIS_BUILD_NUMBER}-${HOST_CLOUD}/g" terraform.tfvars
-  - sed -i -e "s/your-kubeadm-token/${CI_KUBETOKEN}/g" terraform.tfvars
-  - sed -i -e 's/use_cloudflare = "false"/use_cloudflare = "true"/g' terraform.tfvars
-  - sed -i -e "s/your-cloudflare-email/${CI_CLOUDFLARE_EMAIL}/g" terraform.tfvars
-  - sed -i -e "s/your-cloudflare-token/${CI_CLOUDFLARE_TOKEN}/g" terraform.tfvars
-  - sed -i -e "s/your-domain-name/${CI_CLOUDFLARE_DOMAIN}/g" terraform.tfvars
-
-  # AWS
-  - sed -i -e "s/your-acces-key-id/${AWS_ACCESS_KEY_ID}/g" terraform.tfvars
-  - sed -i -e "s#your-secret-access-key#${AWS_SECRET_ACCESS_KEY}#g" terraform.tfvars
-  # GCE
-  - printf '%s\n' "$GCE_CREDENTIALS" > "$HOME/account_file.json"
-  - sed -i -e "s/your_project_id/${GCE_PROJECT_ID}/g" terraform.tfvars
-  # OS
-  - sed -i -e "s/your-pool-name/${OS_POOL_NAME}/g" terraform.tfvars
-  - sed -i -e "s/external-net-uuid/${OS_EXTERNAL_NET_UUUID}/g" terraform.tfvars
-  - sed -i -e "s/your-master-flavor/${OS_MASTER_FLAVOR}/g" terraform.tfvars
-  - sed -i -e "s/your-node-flavor/${OS_NODE_FLAVOR}/g" terraform.tfvars
-  - sed -i -e "s/your-edge-flavor/${OS_EDGE_FLAVOR}/g" terraform.tfvars
-
-  # Check code quality
-  # check Terraform
-  - terraform fmt common/cloudflare
-  - terraform fmt common/inventory
-  - terraform fmt "$HOST_CLOUD"
-  - git diff --exit-code # this will fail if terraform changed something
-  # check Ansible
-  # skip ANSIBLE0006: avoid using curl
-  # skip ANSIBLE0012: missing change_when on command/shell etc.
-  - ansible-lint -x ANSIBLE0006,ANSIBLE0012 playbooks/*.yml
-  # check Shell
-  - shellcheck $(find . -type f -name "*.sh")
-
-script:
-  # AWS doesn't need image import
-  - >
-      if [ "$HOST_CLOUD" = 'openstack' ] || [ "$HOST_CLOUD" = 'gce' ]; then
-        ansible-playbook \
-        -e "credentials_file_path=$HOME/account_file.json" \
-        playbooks/import-"$HOST_CLOUD"-image.yml
-      fi
-  - terraform get "$HOST_CLOUD"
-  - travis_retry terraform apply "$HOST_CLOUD"
-  - ansible-playbook playbooks/install-core.yml
-  - ansible-playbook playbooks/infra-test.yml
-
-after_script:
-  - travis_retry terraform destroy -force "$HOST_CLOUD"
+after_script: after_script.sh

--- a/ci/after_script.sh
+++ b/ci/after_script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Destroy no matter what!
+travis_retry terraform destroy -force "$HOST_CLOUD"

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Generate keypair
+mkdir -p keypair
+ssh-keygen -q -t rsa -N "" -f keypair/kubenow-ci
+
+# Add the keypair to the agent
+eval "$(ssh-agent -s)"
+ssh-add keypair/kubenow-ci

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Render Terraform configuration
+# Common
+if [ "$HOST_CLOUD" = 'openstack' ]; then
+  cp terraform.tfvars.os-template terraform.tfvars
+else
+  cp "terraform.tfvars.${HOST_CLOUD}-template" terraform.tfvars
+fi
+
+mkdir -p "$HOME/.ssh/" && cp keypair/kubenow-ci.pub "$HOME/.ssh/id_rsa.pub"
+sed -i -e "s/your-cluster-prefix/kubenow-ci-${TRAVIS_BUILD_NUMBER}-${HOST_CLOUD}/g" terraform.tfvars
+sed -i -e "s/your-kubeadm-token/${CI_KUBETOKEN}/g" terraform.tfvars
+sed -i -e 's/use_cloudflare = "false"/use_cloudflare = "true"/g' terraform.tfvars
+sed -i -e "s/your-cloudflare-email/${CI_CLOUDFLARE_EMAIL}/g" terraform.tfvars
+sed -i -e "s/your-cloudflare-token/${CI_CLOUDFLARE_TOKEN}/g" terraform.tfvars
+sed -i -e "s/your-domain-name/${CI_CLOUDFLARE_DOMAIN}/g" terraform.tfvars
+
+# AWS
+sed -i -e "s/your-acces-key-id/${AWS_ACCESS_KEY_ID}/g" terraform.tfvars
+sed -i -e "s#your-secret-access-key#${AWS_SECRET_ACCESS_KEY}#g" terraform.tfvars
+# GCE
+printf '%s\n' "$GCE_CREDENTIALS" > "$HOME/account_file.json"
+sed -i -e "s/your_project_id/${GCE_PROJECT_ID}/g" terraform.tfvars
+# OS
+sed -i -e "s/your-pool-name/${OS_POOL_NAME}/g" terraform.tfvars
+sed -i -e "s/external-net-uuid/${OS_EXTERNAL_NET_UUUID}/g" terraform.tfvars
+sed -i -e "s/your-master-flavor/${OS_MASTER_FLAVOR}/g" terraform.tfvars
+sed -i -e "s/your-node-flavor/${OS_NODE_FLAVOR}/g" terraform.tfvars
+sed -i -e "s/your-edge-flavor/${OS_EDGE_FLAVOR}/g" terraform.tfvars
+
+# Check code quality
+# check Terraform
+terraform fmt common/cloudflare
+terraform fmt common/inventory
+terraform fmt "$HOST_CLOUD"
+git diff --exit-code # this will fail if terraform changed something
+# check Ansible
+# skip ANSIBLE0006: avoid using curl
+# skip ANSIBLE0012: missing change_when on command/shell etc.
+ansible-lint -x ANSIBLE0006,ANSIBLE0012 playbooks/*.yml
+# check Shell
+shellcheck "$(find . -type f -name '*.sh')"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Install Terraform
+travis_retry curl \
+  "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
+  > /tmp/terraform.zip
+sudo unzip /tmp/terraform.zip -d /usr/bin
+sudo chmod +x /usr/bin/terraform
+
+# Install Ansible and pip deps
+sudo pip install --upgrade pip
+sudo pip install \
+  ansible=="${ANSIBLE_VERSION}" \
+  j2cli \
+  dnspython \
+  jmespath \
+  backports.ssl_match_hostname \
+  apache-libcloud=="${LIBCLOUD_VERSION}" \
+  shade \
+  ansible-lint=="${ANSIBLE_LINT_VERSION}"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# AWS doesn't need image import
+if [ "$HOST_CLOUD" = 'openstack' ] || [ "$HOST_CLOUD" = 'gce' ]; then
+  ansible-playbook \
+    -e "credentials_file_path=$HOME/account_file.json" \
+    playbooks/import-"$HOST_CLOUD"-image.yml
+fi
+
+# Deploy KubeNow
+terraform get "$HOST_CLOUD"
+travis_retry terraform apply "$HOST_CLOUD"
+ansible-playbook playbooks/install-core.yml
+ansible-playbook playbooks/infra-test.yml


### PR DESCRIPTION
## Change content and motivation
Split CI descriptor in smaller scripts. Apart from being cleaner this allows to shellcheck the CI process.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
