### PR TITLE
One command deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,20 +106,13 @@ before_script:
   - sed -i -e "s/your-domain-name/${CI_CLOUDFLARE_DOMAIN}/g" terraform.tfvars
 
 script:
-  # Import image (AWS doesn't need it)
-  - >
-      if [ "$HOST_CLOUD" = 'openstack' ] || [ "$HOST_CLOUD" = 'gce' ]; then
-        ../bin/kn ansible-playbook playbooks/import-"$HOST_CLOUD"-image.yml
-      fi
   # Deploy
-  - ../bin/kn terraform get "$HOST_CLOUD"
-  - travis_retry ../bin/kn terraform apply "$HOST_CLOUD"
-  - ../bin/kn ansible-playbook playbooks/install-core.yml
+  - travis_retry ../bin/kn apply "$HOST_CLOUD"
   # Test
   - ../bin/kn ansible-playbook playbooks/infra-test.yml
 
 after_script:
-  - travis_retry ../bin/kn terraform destroy -force "$HOST_CLOUD"
+  - export TERRAFORM_OPT="-force" && travis_retry ../bin/kn destroy "$HOST_CLOUD"
   - travis_retry terraform destroy -force "$HOST_CLOUD" # in case there is some problem with kn
 
 jobs:

--- a/bin/apply
+++ b/bin/apply
@@ -25,5 +25,7 @@ fi
 
 # Deploy
 terraform get -update "$HOST_CLOUD"
-terraform apply "$TERRAFORM_OPT" "$HOST_CLOUD"
-ansible-playbook "$ANSIBLE_OPT" playbooks/install-core.yml
+# shellcheck disable=SC2086
+terraform apply $TERRAFORM_OPT "$HOST_CLOUD"
+# shellcheck disable=SC2086
+ansible-playbook $ANSIBLE_OPT playbooks/install-core.yml

--- a/bin/apply
+++ b/bin/apply
@@ -11,18 +11,20 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 HOST_CLOUD="$1"
-ALLOWED="aws gce openstack"
-if [[ ! "$ALLOWED" =~ $HOST_CLOUD ]]; then
+if [ "$HOST_CLOUD" != 'openstack' ] && \
+  [ "$HOST_CLOUD" != 'gce' ] && \
+  [ "$HOST_CLOUD" != 'aws' ]; then
   >&2 echo "Error: unrecognized host cloud '$HOST_CLOUD'"
   echo "$USAGE"
   exit 1
 fi
 
+#Exit immediately if a command exits with a non-zero status
+set -e
 # Import image (AWS doesn't need it)
 if [ "$HOST_CLOUD" = 'openstack' ] || [ "$HOST_CLOUD" = 'gce' ]; then
   ansible-playbook playbooks/import-"$HOST_CLOUD"-image.yml
 fi
-
 # Deploy
 terraform get -update "$HOST_CLOUD"
 # shellcheck disable=SC2086

--- a/bin/apply
+++ b/bin/apply
@@ -1,0 +1,29 @@
+#!/bin/ash
+# shellcheck shell=bash
+
+#Usage
+USAGE="Usage: kn apply <aws|gce|openstack>"
+
+# Validate command
+if [ "$#" -eq 0 ]; then
+  >&2 echo "Error: no arguments supplied"
+  echo "$USAGE"
+  exit 1
+fi
+HOST_CLOUD="$1"
+ALLOWED="aws gce openstack"
+if [[ ! "$ALLOWED" =~ $HOST_CLOUD ]]; then
+  >&2 echo "Error: unrecognized host cloud '$HOST_CLOUD'"
+  echo "$USAGE"
+  exit 1
+fi
+
+# Import image (AWS doesn't need it)
+if [ "$HOST_CLOUD" = 'openstack' ] || [ "$HOST_CLOUD" = 'gce' ]; then
+  ansible-playbook playbooks/import-"$HOST_CLOUD"-image.yml
+fi
+
+# Deploy
+terraform get -update "$HOST_CLOUD"
+terraform apply "$TERRAFORM_OPT" "$HOST_CLOUD"
+ansible-playbook "$ANSIBLE_OPT" playbooks/install-core.yml

--- a/bin/destroy
+++ b/bin/destroy
@@ -1,0 +1,22 @@
+#!/bin/ash
+# shellcheck shell=bash
+
+#Usage
+USAGE="Usage: kn destroy <aws|gce|openstack>"
+
+# Validate command
+if [ "$#" -eq 0 ]; then
+  >&2 echo "Error: no arguments supplied"
+  echo "$USAGE"
+  exit 1
+fi
+HOST_CLOUD="$1"
+ALLOWED="aws gce openstack"
+if [[ ! "$ALLOWED" =~ $HOST_CLOUD ]]; then
+  >&2 echo "Error: unrecognized host cloud '$HOST_CLOUD'"
+  echo "$USAGE"
+  exit 1
+fi
+
+# Destroy
+terraform destroy "$TERRAFORM_OPT" "$HOST_CLOUD"

--- a/bin/destroy
+++ b/bin/destroy
@@ -19,4 +19,5 @@ if [[ ! "$ALLOWED" =~ $HOST_CLOUD ]]; then
 fi
 
 # Destroy
-terraform destroy "$TERRAFORM_OPT" "$HOST_CLOUD"
+# shellcheck disable=SC2086
+terraform destroy $TERRAFORM_OPT "$HOST_CLOUD"

--- a/bin/destroy
+++ b/bin/destroy
@@ -11,8 +11,9 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 HOST_CLOUD="$1"
-ALLOWED="aws gce openstack"
-if [[ ! "$ALLOWED" =~ $HOST_CLOUD ]]; then
+if [ "$HOST_CLOUD" != 'openstack' ] && \
+  [ "$HOST_CLOUD" != 'gce' ] && \
+  [ "$HOST_CLOUD" != 'aws' ]; then
   >&2 echo "Error: unrecognized host cloud '$HOST_CLOUD'"
   echo "$USAGE"
   exit 1

--- a/bin/kn
+++ b/bin/kn
@@ -6,6 +6,9 @@ Usage: kn <command>
 Commands:
   help                print this message
   init <DIR>          creates a new project in the supplied directory
+  apply <CLOUD>       apply configuration on the supplied cloud provider.
+                      CLOUD=<gce|aws|openstack>
+  destroy <CLOUD>     destroy deployment (CLOUD=<gce|aws|openstack>)
   terraform           run Terraform. More help: kn terraform --help
   ansible             run Ansible. More help: kn ansible --help
   ansible-playbook    run an Ansible playbook.
@@ -20,7 +23,7 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 COMMAND="$1"
-ALLOWED="help init terraform ansible ansible-playbook kubetoken"
+ALLOWED="help init terraform ansible ansible-playbook kubetoken apply destroy"
 if [[ ! "$ALLOWED" =~ $COMMAND ]]; then
   >&2 echo "Error: unrecognized command '$COMMAND'"
   echo "$USAGE"

--- a/bin/kn
+++ b/bin/kn
@@ -82,6 +82,8 @@ USR_COMMAND="$*"
 docker run --rm -it \
   -v "$PWD":/var/userdir \
   -e "HOST_USR_UID=$UID" \
+  -e "TERRAFORM_OPT=$TERRAFORM_OPT" \
+  -e "ANSIBLE_OPT=$ANSIBLE_OPT" \
   -e "OS_USERNAME=$OS_USERNAME" \
   -e "OS_PASSWORD=$OS_PASSWORD" \
   -e "OS_AUTH_URL=$OS_AUTH_URL" \


### PR DESCRIPTION
## Change content and motivation
This PR introduces two subcommands for the `kn` CLI. The `apply` command deploys KubeNow and the `destroy` command destroys it. The multi-step deployment is still supported.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
