### PR TITLE
Fix zero edge inventory workaround

### DIFF
--- a/common/inventory/main.tf
+++ b/common/inventory/main.tf
@@ -42,16 +42,17 @@ resource "null_resource" "generate-inventory" {
   provisioner "local-exec" {
     command = "echo \"[edge]\" >> inventory"
   }
-
-  # output the lists formated
-  provisioner "local-exec" {
-    command = "echo \"${join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", var.edge_hostnames, var.edge_public_ip))}\" >> inventory"
-  }
-
+  
   # only output if master is edge
   provisioner "local-exec" {
     command = "echo \"${var.master_as_edge != true ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", var.master_hostnames, var.master_public_ip))}\" >> inventory"
   }
+  
+  # output the lists formated, slice list to make sure hostname- and ip-list have same length
+  provisioner "local-exec" {
+    command =  "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(module.master.hostnames,0,var.edge_count), module.edge.public_ip))}\" >> inventory"
+  }
+
 
   # Write other variables
   provisioner "local-exec" {

--- a/common/inventory/main.tf
+++ b/common/inventory/main.tf
@@ -50,7 +50,7 @@ resource "null_resource" "generate-inventory" {
 
   # output the lists formated, slice list to make sure hostname- and ip-list have same length
   provisioner "local-exec" {
-    command = "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(var.master_hostnames,0,var.edge_count), var.edge_public_ip))}\" >> inventory"
+    command = "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(var.edge_hostnames,0,var.edge_count), var.edge_public_ip))}\" >> inventory"
   }
 
   # Write other variables

--- a/common/inventory/main.tf
+++ b/common/inventory/main.tf
@@ -48,7 +48,7 @@ resource "null_resource" "generate-inventory" {
     command = "echo \"${var.master_as_edge != true ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", var.master_hostnames, var.master_public_ip))}\" >> inventory"
   }
 
-  # output the lists formated, slice list to make sure hostname- and ip-list have same length
+  # output the lists formated, slice list to make sure hostname and ip-list have same length
   provisioner "local-exec" {
     command = "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(var.edge_hostnames,0,var.edge_count), var.edge_public_ip))}\" >> inventory"
   }

--- a/common/inventory/main.tf
+++ b/common/inventory/main.tf
@@ -53,7 +53,6 @@ resource "null_resource" "generate-inventory" {
     command =  "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(module.master.hostnames,0,var.edge_count), module.edge.public_ip))}\" >> inventory"
   }
 
-
   # Write other variables
   provisioner "local-exec" {
     command = "echo \"[master:vars]\" >> inventory"

--- a/common/inventory/main.tf
+++ b/common/inventory/main.tf
@@ -50,7 +50,7 @@ resource "null_resource" "generate-inventory" {
 
   # output the lists formated, slice list to make sure hostname- and ip-list have same length
   provisioner "local-exec" {
-    command = "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(module.master.hostnames,0,var.edge_count), module.edge.public_ip))}\" >> inventory"
+    command = "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(var.master_hostnames,0,var.edge_count), var.edge_public_ip))}\" >> inventory"
   }
 
   # Write other variables

--- a/common/inventory/main.tf
+++ b/common/inventory/main.tf
@@ -42,15 +42,15 @@ resource "null_resource" "generate-inventory" {
   provisioner "local-exec" {
     command = "echo \"[edge]\" >> inventory"
   }
-  
+
   # only output if master is edge
   provisioner "local-exec" {
     command = "echo \"${var.master_as_edge != true ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", var.master_hostnames, var.master_public_ip))}\" >> inventory"
   }
-  
+
   # output the lists formated, slice list to make sure hostname- and ip-list have same length
   provisioner "local-exec" {
-    command =  "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(module.master.hostnames,0,var.edge_count), module.edge.public_ip))}\" >> inventory"
+    command = "echo \"${var.edge_count == 0 ? "" : join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu", slice(module.master.hostnames,0,var.edge_count), module.edge.public_ip))}\" >> inventory"
   }
 
   # Write other variables


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
Fixes terraform error if edge count is zero and changes order so master is writtern first in the edge list.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
