### PR TITLE
Use bash instead of ash in the provisioners container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apk add --update \
   linux-headers \
   libffi-dev \
   openssl-dev \
-  openssl
+  openssl \
+  bash
 
 # Install PIP deps
 RUN pip install \

--- a/bin/apply
+++ b/bin/apply
@@ -1,5 +1,4 @@
-#!/bin/ash
-# shellcheck shell=bash
+#!/bin/bash
 
 #Usage
 USAGE="Usage: kn apply <aws|gce|openstack>"

--- a/bin/destroy
+++ b/bin/destroy
@@ -1,5 +1,4 @@
-#!/bin/ash
-# shellcheck shell=bash
+#!/bin/bash
 
 #Usage
 USAGE="Usage: kn destroy <aws|gce|openstack>"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,5 +1,4 @@
-#!/bin/ash
-# shellcheck shell=bash
+#!/bin/bash
 
 # Copy host PWD in container PWD
 cp /var/userdir/terraform.tfvars ./ 2>/dev/null

--- a/bin/init-kn
+++ b/bin/init-kn
@@ -1,5 +1,4 @@
-#!/bin/ash
-# shellcheck shell=bash
+#!/bin/bash
 
 echo "Initializing $INIT_DIR deployment directory..."
 

--- a/bin/kubetoken
+++ b/bin/kubetoken
@@ -1,5 +1,4 @@
-#!/bin/ash
-# shellcheck shell=bash
+#!/bin/bash
 # kube token format: 7fa96f.ddb39492a1894689
 # see https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/tokens.go
 tokenID=$(openssl rand -hex 3)


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
