### PR TITLE
Improved waiting-for-nodes-ready-playbook

### DIFF
--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -3,7 +3,7 @@
   local_action: wait_for
     host={{ ansible_ssh_host | default(inventory_hostname) }}
     port={{ ansible_port | default(22) }}
-    search_regex=OpenSSH
+    state=started
     delay=0
     connect_timeout=1
     timeout=300
@@ -12,7 +12,7 @@
   local_action: wait_for
     host={{ ansible_ssh_host | default(inventory_hostname) }}
     port={{ ansible_port | default(22) }}
-    state=started
+    search_regex=OpenSSH
     delay=0
     connect_timeout=1
     timeout=300

--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -49,7 +49,6 @@
   rescue:
 
   - name: "get cloud-init log"
-    become: yes
     command: >
       cat /var/log/cloud-init-output.log
     register: cloud_init_log

--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -7,7 +7,7 @@
     delay=0
     connect_timeout=1
     timeout=300
-    
+
 - name: "wait for server to respond on ssh port - second check"
   local_action: wait_for
     host={{ ansible_ssh_host | default(inventory_hostname) }}
@@ -60,3 +60,5 @@
 
   # now fail when log output is printed
   - name: fail play
+    fail:
+      msg: "Error in node init process, hopefully the master node cloud-init log above can help solving the issue"

--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -12,7 +12,7 @@
   local_action: wait_for
     host={{ ansible_ssh_host | default(inventory_hostname) }}
     port={{ ansible_port | default(22) }}
-    state: started
+    state=started
     delay=0
     connect_timeout=1
     timeout=300

--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -4,37 +4,59 @@
     host={{ ansible_ssh_host | default(inventory_hostname) }}
     port={{ ansible_port | default(22) }}
     search_regex=OpenSSH
-    delay=10
+    delay=0
+    connect_timeout=1
+    timeout=300
+    
+- name: "wait for server to respond on ssh port - second check"
+  local_action: wait_for
+    host={{ ansible_ssh_host | default(inventory_hostname) }}
+    port={{ ansible_port | default(22) }}
+    state: started
+    delay=0
+    connect_timeout=1
     timeout=300
 
-- name: "render node count"
-  local_action: >
-    shell
-    cat terraform.tfvars |
-    grep '[node|edge]_count' |
-    awk '{print $3;}' |
-    tr -d '"' |
-    awk '{s+=$1} END {print s}'
-  args:
-    chdir: "{{playbook_dir}}/.."
-  register: get_nodes_count
-  when:
-    - nodes_count is undefined
+# if task in block fails - rescue and always output cloud-init log as debug info
+- block:
 
-- name: "set nodes_count fact"
-  set_fact:
-    # +1 because master is also one node
-    nodes_count: "{{(get_nodes_count.stdout | int) + 1}}"
-  when:
-    - nodes_count is undefined
+  - name: "wait until for cloud-init to finish on master"
+    shell: >
+      tail -1 /var/log/cloud-init-output.log | grep 'Cloud-init.*finished'
+    register: grep_init_finished
+    until: grep_init_finished.rc == 0
+    # Wait for 5 minutes
+    retries: 60
+    delay: 5
 
-- name: "wait for all nodes to join the master"
-  shell: >
-    kubectl get nodes
-    -o jsonpath='{.items[*].status.conditions[-1:].type}' |
-    grep -o 'Ready' | wc -l
-  register: get_ready_nodes
-  until: "{{get_ready_nodes.stdout | int}} == {{nodes_count | int}}"
-  # Wait for 5 minutes
-  retries: 60
-  delay: 5
+  - name: "verify that master initialized ok"
+    shell: >
+      cat /var/log/cloud-init-output.log | grep 'Kubernetes master has initialized successfully'
+    register: grep_master_initialized
+    failed_when: grep_master_initialized.rc != 0
+
+  - name: "wait for all nodes to join the master"
+    shell: >
+      kubectl get nodes
+      -o jsonpath='{.items[*].status.conditions[-1:].type}' |
+      grep -o 'Ready' | wc -l
+    register: get_ready_nodes
+    until: (get_ready_nodes.stdout | int) == (nodes_count | int)
+    # Wait for 5 minutes
+    retries: 60
+    delay: 5
+
+  rescue:
+
+  - name: "get cloud-init log"
+    become: yes
+    command: >
+      cat /var/log/cloud-init-output.log
+    register: cloud_init_log
+
+  - name: print master cloud init log
+    debug:
+      msg: "{{ cloud_init_log.stdout }}"
+
+  # now fail when log output is printed
+  - name: fail play

--- a/playbooks/roles/common/tasks/wait-nodes.yml
+++ b/playbooks/roles/common/tasks/wait-nodes.yml
@@ -4,8 +4,7 @@
     host={{ ansible_ssh_host | default(inventory_hostname) }}
     port={{ ansible_port | default(22) }}
     state=started
-    delay=0
-    connect_timeout=1
+    connect_timeout=10
     timeout=300
 
 - name: "wait for server to respond on ssh port - second check"
@@ -13,8 +12,7 @@
     host={{ ansible_ssh_host | default(inventory_hostname) }}
     port={{ ansible_port | default(22) }}
     search_regex=OpenSSH
-    delay=0
-    connect_timeout=1
+    connect_timeout=10
     timeout=300
 
 # if task in block fails - rescue and always output cloud-init log as debug info


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
- Adds task that read cloud-init log and waits until cloud init is finished, then checks if Master init message is OK in log.
- If waiting for cloud-init to finish or nodes to join master fails, then cloud-init log is outputed to user for debug purposes.
- Updated initial wait for ssh with second check for ssh up.
- Changes values in wait_for task.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
