### PR TITLE
Untaint kubernetes master if it is a single node deployment

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -1,2 +1,3 @@
 - include: wait-nodes.yml
 - include: workaround-RBAC.yml
+- { include: untaint_master.yml, when: nodes_count == 1 }

--- a/playbooks/roles/common/tasks/untaint_master.yml
+++ b/playbooks/roles/common/tasks/untaint_master.yml
@@ -1,0 +1,5 @@
+---
+- name: "untaint master if it is the only node"
+  command: >
+    kubectl taint nodes
+    --all node-role.kubernetes.io/master-


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
Untaint the kubernetes master if it is the only node. This allows for single node KubeNow installations since the untainted master will allow for all pod scheduling.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
