### PR TITLE
Set identity API in provisioners, to fix openstack CLI

### DIFF
--- a/bin/kn
+++ b/bin/kn
@@ -100,5 +100,6 @@ docker run --rm -it \
   -e "OS_TENANT_ID=$OS_TENANT_ID" \
   -e "OS_TENANT_NAME=$OS_TENANT_NAME" \
   -e "OS_AUTH_VERSION=$OS_AUTH_VERSION" \
+  -e "OS_IDENTITY_API_VERSION=$OS_AUTH_VERSION" \
   kubenow/provisioners:"$KUBENOW_VERSION" \
   "$USR_COMMAND"


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
Set identity API in provisioners, to fix `openstack` CLI. The CLI reads the identity API version from 
`OS_IDENTITY_API_VERSION`.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
