### PR TITLE
Use Flannel instead of Weave

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ kn helm install my-app-package
 Deploying a KubeNow cluster you will get:
 
  - A Kubernetes cluster up and running in ~10 minutes (provisioned with [kubeadm](http://kubernetes.io/docs/getting-started-guides/kubeadm/))
- - [Weave](https://www.weave.works/) networking
+ - [Flannel](https://github.com/coreos/flannel) networking
  - [Traefik](https://traefik.io/) HTTP reverse proxy and load balancer
  - [Cloudflare](https://www.cloudflare.com/) dynamic DNS configuration
  - [GlusterFS](https://www.gluster.org/) distributed file system
@@ -74,7 +74,7 @@ Want to try KubeNow? You can get started following the tutorials in the document
 - [x] Traefik
 
 ### Networking
-- [x] Weave
+- [x] Flannel
 
 ### Big Data Frameworks
 - [ ] Spark

--- a/bootstrap/master.sh
+++ b/bootstrap/master.sh
@@ -34,10 +34,10 @@ echo "Inititializing the master...."
 if [ -n "$API_ADVERTISE_ADDRESSES" ]
 then
     # shellcheck disable=SC2154
-    kubeadm init --token "${kubeadm_token}" --kubernetes-version=v1.7.5 --api-advertise-address="$API_ADVERTISE_ADDRESSES"
+    kubeadm init --token "${kubeadm_token}" --pod-network-cidr=10.244.0.0/16 --kubernetes-version=v1.7.5 --api-advertise-address="$API_ADVERTISE_ADDRESSES"
 else
     # shellcheck disable=SC2154
-    kubeadm init --token "${kubeadm_token}" --kubernetes-version=v1.6.4
+    kubeadm init --token "${kubeadm_token}" --pod-network-cidr=10.244.0.0/16 --kubernetes-version=v1.7.5
 fi
 
 # Copy Kubernetes configuration created by kubeadm (admin.conf to .kube/config)

--- a/playbooks/install-core.yml
+++ b/playbooks/install-core.yml
@@ -2,7 +2,8 @@
   gather_facts: False
   roles:
     - { role: common, tags: [ 'minimal' ] }
-    - { role: weave-network, tags: [ 'minimal' ] }
+    - { role: flannel-network, tags: [ 'minimal' ] }
+    - { role: wait-kube-dns, tags: [ 'minimal' ] }
     - { role: start-helm, tags: [ 'minimal' ] }
     - { role: traefik, tags: [ 'traefik' ] }
     - { role: heketi-gluster, tags: [ 'heketi-glusterfs' ] }

--- a/playbooks/roles/flannel-network/tasks/main.yml
+++ b/playbooks/roles/flannel-network/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: "install flannel-network"
+  command: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.0/Documentation/kube-flannel.yml
+
+- name: "apply flannel-network rbac"
+  command: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.0/Documentation/kube-flannel-rbac.yml

--- a/playbooks/roles/flannel-network/tasks/main.yml
+++ b/playbooks/roles/flannel-network/tasks/main.yml
@@ -1,6 +1,3 @@
 ---
 - name: "install flannel-network"
   command: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.0/Documentation/kube-flannel.yml
-
-- name: "apply flannel-network rbac"
-  command: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.0/Documentation/kube-flannel-rbac.yml

--- a/playbooks/roles/wait-kube-dns/tasks/main.yml
+++ b/playbooks/roles/wait-kube-dns/tasks/main.yml
@@ -1,0 +1,11 @@
+
+# Testing kube-dns if pod is ready
+- name: "get kube-dns ready status"
+  command: >
+    kubectl get pods -l k8s-app=kube-dns --namespace=kube-system
+    -o jsonpath='{.items[*].status.containerStatuses[*].ready}'
+  register: get_is_ready
+  until: get_is_ready.stdout | match( '^(true\s)*true$' )
+  # Wait for 10 minutes
+  retries: 120
+  delay: 5


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
-->

## Change content and motivation
- Change to flannel network instead of weave (Weave networking has caused random errors that has caused kube-proxy and kube-dns not to start on some nodes when deploying large clusters on Openstack or during Microsoft Azure development) - Hopefully this will also remedy some of the random errors we have seen during continous integration testing!
- Adds dns-wait ansible role after network installation
- Fixes kubernetes version error in bootstrap/master.sh

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
