### PR TITLE
Skip travis retry and add travis debug-ssh-key and rename var in ansible.cfg 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,8 @@ before_script:
   - cd test-deployment
   
   # Overwrite ssh-key for debug purposes
-  - printf '%s' "$TRAVIS_SSH_KEY_PRIV" > ssh_key
-  - printf '%s' "$TRAVIS_SSH_KEY_PUB" > ssh_key.pub
+  - echo -e "$TRAVIS_SSH_KEY_PRIV" > ssh_key
+  - echo -e "$TRAVIS_SSH_KEY_PUB" > ssh_key.pub
 
   # RENDER CONFIGURATION
   # Create terraform.tfvars

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ before_script:
 
 script:
   # Deploy
-  - travis_retry ../bin/kn apply "$HOST_CLOUD"
+  - ../bin/kn apply "$HOST_CLOUD"
   # Test
   - ../bin/kn ansible-playbook playbooks/infra-test.yml
   - ../bin/kn kubectl get nodes # try to list nodes

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,10 @@ before_script:
   # Init test deployment
   - bin/kn init test-deployment
   - cd test-deployment
+  
+  # Overwrite ssh-key for debug purposes
+  - printf '%s' "$TRAVIS_SSH_KEY_PRIV" > ssh_key
+  - printf '%s' "$TRAVIS_SSH_KEY_PUB" > ssh_key.pub
 
   # RENDER CONFIGURATION
   # Create terraform.tfvars

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 host_key_checking=False
-hostfile=inventory
+inventory=inventory
 
 [ssh_connection]
 pipelining=True


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation

- Improves debug possibilities by using a pre-defined ssh-key from travis settings to enable access to travis deployed machines for debug purposes

- Skip travis_retry since it hardly ever leads to a successful deployment

- Update ansible.cfg with new parameter name instead of deprecated "hostname" parameter

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
