### PR TITLE
New traefik version, optional StorageClassName to pvc-template and changes in node tainting

### DIFF
--- a/playbooks/roles/common/tasks/untaint_master.yml
+++ b/playbooks/roles/common/tasks/untaint_master.yml
@@ -1,8 +1,7 @@
 ---
-# ignore_errors because kubectl will exit with errorcode if taint doesn't exist,
-# which is the case if playbook is being run twice
-- name: "untaint master if it is the only node"
-  command: >
-    kubectl taint nodes
-    --all node-role.kubernetes.io/master-
-  ignore_errors: yes
+# First jq-filter nodes having taint and then untaint command
+- name: "untaint master"
+  shell: >
+    kubectl get nodes -o json
+      | jq ".items[] | select(.spec.taints[]?.key==\"node-role.kubernetes.io/master\") | .metadata.name"
+      | xargs -L1 -i kubectl taint nodes {} node-role.kubernetes.io/master-

--- a/playbooks/roles/common/tasks/untaint_master.yml
+++ b/playbooks/roles/common/tasks/untaint_master.yml
@@ -1,5 +1,8 @@
 ---
+# ignore_errors because kubectl will exit with errorcode if taint doesn't exist,
+# which is the case if playbook is being run twice
 - name: "untaint master if it is the only node"
   command: >
     kubectl taint nodes
     --all node-role.kubernetes.io/master-
+  ignore_errors: yes

--- a/playbooks/roles/pvc/templates/template-pvc.yml
+++ b/playbooks/roles/pvc/templates/template-pvc.yml
@@ -9,3 +9,6 @@ spec:
   resources:
     requests:
       storage: {{storage}}
+{% if storageClassName is defined %}
+  storageClassName: {{ storageClassName }}
+{% endif %}

--- a/playbooks/roles/traefik/files/traefik-daemonset.yml
+++ b/playbooks/roles/traefik/files/traefik-daemonset.yml
@@ -19,7 +19,7 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:
-      - image: traefik:v1.4.2
+      - image: traefik:v1.3.8
         name: traefik-ingress-lb
         imagePullPolicy: Always
         volumeMounts:

--- a/playbooks/roles/traefik/files/traefik-daemonset.yml
+++ b/playbooks/roles/traefik/files/traefik-daemonset.yml
@@ -19,7 +19,7 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:
-      - image: traefik:v1.3.1
+      - image: traefik:v1.4.2
         name: traefik-ingress-lb
         imagePullPolicy: Always
         volumeMounts:


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
Various changes from downstream phenomenal project:
- New traefik version 1.4.2
- Optional StorageClassName to pvc-template
- Changes in node tainting

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
