### PR TITLE
Fixes wrong id when using existing aws vpc network

### DIFF
--- a/aws/subnet/main.tf
+++ b/aws/subnet/main.tf
@@ -60,5 +60,12 @@ resource "aws_route_table_association" "main" {
 }
 
 output "id" {
-  value = "${ var.subnet_id != "" ? var.subnet_id : aws_subnet.created.id }"
+  # The join() hack is required because currently the ternary operator
+  # evaluates the expressions on both branches of the condition before
+  # returning a value. When providing and external VPC, the template VPC
+  # resource gets a count of zero which triggers an evaluation error.
+  #
+  # This is tracked upstream: https://github.com/hashicorp/hil/issues/50
+  #
+  value = "${ var.subnet_id == "" ? join(" ", aws_subnet.created.*.id) : var.subnet_id }"
 }

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -19,5 +19,12 @@ resource "aws_vpc" "created" {
 }
 
 output "id" {
-  value = "${ var.vpc_id != "" ? var.vpc_id : aws_vpc.created.id }"
+  # The join() hack is required because currently the ternary operator
+  # evaluates the expressions on both branches of the condition before
+  # returning a value. When providing and external VPC, the template VPC
+  # resource gets a count of zero which triggers an evaluation error.
+  #
+  # This is tracked upstream: https://github.com/hashicorp/hil/issues/50
+  #
+  value = "${ var.vpc_id == "" ? join(" ", aws_vpc.created.*.id) : var.vpc_id }"
 }


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
Fixes wrong id when using existing aws vpc network

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
