### PR TITLE
Optional existing openstack network and secgroup creation to own module

### DIFF
--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -13,6 +13,14 @@ variable ssh_key {
   default = "ssh_key.pub"
 }
 
+variable network_name {
+  default = ""
+}
+
+variable secgroup_name {
+  default = ""
+}
+
 variable external_network_uuid {}
 
 variable dns_nameservers {
@@ -120,12 +128,20 @@ module "keypair" {
   name_prefix = "${var.cluster_prefix}"
 }
 
-# Network (here would be nice with condition)
+# Network
 module "network" {
   source            = "./network"
+  network_name      = "${var.network_name}"
   external_net_uuid = "${var.external_network_uuid}"
   name_prefix       = "${var.cluster_prefix}"
   dns_nameservers   = "${var.dns_nameservers}"
+}
+
+# Secgroup
+module "secgroup" {
+  source        = "./secgroup"
+  secgroup_name = "${var.secgroup_name}"
+  name_prefix   = "${var.cluster_prefix}"
 }
 
 module "master" {
@@ -143,7 +159,7 @@ module "master" {
 
   # Network settings
   network_name       = "${module.network.network_name}"
-  secgroup_name      = "${module.network.secgroup_name}"
+  secgroup_name      = "${module.secgroup.secgroup_name}"
   assign_floating_ip = "true"
   floating_ip_pool   = "${var.floating_ip_pool}"
 
@@ -173,7 +189,7 @@ module "node" {
 
   # Network settings
   network_name       = "${module.network.network_name}"
-  secgroup_name      = "${module.network.secgroup_name}"
+  secgroup_name      = "${module.secgroup.secgroup_name}"
   assign_floating_ip = "false"
   floating_ip_pool   = ""
 
@@ -203,7 +219,7 @@ module "edge" {
 
   # Network settings
   network_name       = "${module.network.network_name}"
-  secgroup_name      = "${module.network.secgroup_name}"
+  secgroup_name      = "${module.secgroup.secgroup_name}"
   assign_floating_ip = "true"
   floating_ip_pool   = "${var.floating_ip_pool}"
 
@@ -233,7 +249,7 @@ module "glusternode" {
 
   # Network settings
   network_name       = "${module.network.network_name}"
-  secgroup_name      = "${module.network.secgroup_name}"
+  secgroup_name      = "${module.secgroup.secgroup_name}"
   assign_floating_ip = "false"
   floating_ip_pool   = "${var.floating_ip_pool}"
 

--- a/openstack/network/main.tf
+++ b/openstack/network/main.tf
@@ -1,5 +1,7 @@
 variable name_prefix {}
 
+variable network_name {}
+
 variable subnet_cidr {
   default = "10.0.0.0/16"
 }
@@ -7,74 +9,46 @@ variable subnet_cidr {
 variable external_net_uuid {}
 variable dns_nameservers {}
 
-resource "openstack_networking_network_v2" "main" {
+resource "openstack_networking_network_v2" "created" {
+  # create only if not specified in var.network_name
+  count          = "${var.network_name == "" ? 1 : 0}"
   name           = "${var.name_prefix}-network"
   admin_state_up = "true"
 }
 
-resource "openstack_networking_subnet_v2" "main" {
-  name            = "${var.name_prefix}-subnet"
-  network_id      = "${openstack_networking_network_v2.main.id}"
-  cidr            = "${var.subnet_cidr}"
-  ip_version      = 4
+resource "openstack_networking_subnet_v2" "created" {
+  # create only if not specified in var.network_name
+  count      = "${var.network_name == "" ? 1 : 0}"
+  name       = "${var.name_prefix}-subnet"
+  network_id = "${openstack_networking_network_v2.created.id}"
+  cidr       = "${var.subnet_cidr}"
+  ip_version = 4
+
   dns_nameservers = ["${compact(split(",", var.dns_nameservers))}"]
   enable_dhcp     = true
 }
 
-resource "openstack_networking_router_v2" "main" {
+resource "openstack_networking_router_v2" "created" {
+  # create only if not specified in var.network_name
+  count            = "${var.network_name == "" ? 1 : 0}"
   name             = "${var.name_prefix}-router"
   external_gateway = "${var.external_net_uuid}"
 }
 
-resource "openstack_networking_router_interface_v2" "main" {
-  router_id = "${openstack_networking_router_v2.main.id}"
-  subnet_id = "${openstack_networking_subnet_v2.main.id}"
-}
-
-resource "openstack_compute_secgroup_v2" "main" {
-  name        = "${var.name_prefix}-secgroup"
-  description = "The automatically created secgroup for ${var.name_prefix}"
-
-  rule {
-    from_port   = 22
-    to_port     = 22
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 80
-    to_port     = 80
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 443
-    to_port     = 443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 1      # All internal tcp traffic
-    to_port     = 65535
-    ip_protocol = "tcp"
-    self        = "true"
-  }
-
-  rule {
-    from_port   = 1      # All internal udp traffic
-    to_port     = 65535
-    ip_protocol = "udp"
-    self        = "true"
-  }
+resource "openstack_networking_router_interface_v2" "created" {
+  # create only if not specified in var.network_name
+  count     = "${var.network_name == "" ? 1 : 0}"
+  router_id = "${openstack_networking_router_v2.created.id}"
+  subnet_id = "${openstack_networking_subnet_v2.created.id}"
 }
 
 output "network_name" {
-  value = "${openstack_networking_network_v2.main.name}"
-}
-
-output "secgroup_name" {
-  value = "${openstack_compute_secgroup_v2.main.name}"
+  # The join() hack is required because currently the ternary operator
+  # evaluates the expressions on both branches of the condition before
+  # returning a value. When providing and external Network, the template Network
+  # resource gets a count of zero which triggers an evaluation error.
+  #
+  # This is tracked upstream: https://github.com/hashicorp/hil/issues/50
+  #
+  value = "${ var.network_name == "" ? join(" ", openstack_networking_network_v2.created.*.name) : var.network_name }"
 }

--- a/openstack/secgroup/main.tf
+++ b/openstack/secgroup/main.tf
@@ -1,0 +1,62 @@
+variable name_prefix {}
+variable secgroup_name {}
+
+resource "openstack_compute_secgroup_v2" "created" {
+  # create only if not specified in var.secgroup_name
+  count       = "${var.secgroup_name == "" ? 1 : 0}"
+  name        = "${var.name_prefix}-secgroup"
+  description = "The automatically created secgroup for ${var.name_prefix}"
+
+  rule {
+    from_port   = 22
+    to_port     = 22
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 80
+    to_port     = 80
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 443
+    to_port     = 443
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 8443
+    to_port     = 8443
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 1      # All internal tcp traffic
+    to_port     = 65535
+    ip_protocol = "tcp"
+    self        = "true"
+  }
+
+  rule {
+    from_port   = 1      # All internal udp traffic
+    to_port     = 65535
+    ip_protocol = "udp"
+    self        = "true"
+  }
+}
+
+output "secgroup_name" {
+  # The join() hack is required because currently the ternary operator
+  # evaluates the expressions on both branches of the condition before
+  # returning a value. When providing and external VPC, the template VPC
+  # resource gets a count of zero which triggers an evaluation error.
+  #
+  # This is tracked upstream: https://github.com/hashicorp/hil/issues/50
+  #
+  value = "${ var.secgroup_name == "" ? join(" ", openstack_compute_secgroup_v2.created.*.name) : var.secgroup_name }"
+}

--- a/openstack/secgroup/main.tf
+++ b/openstack/secgroup/main.tf
@@ -29,13 +29,6 @@ resource "openstack_compute_secgroup_v2" "created" {
   }
 
   rule {
-    from_port   = 8443
-    to_port     = 8443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
     from_port   = 1      # All internal tcp traffic
     to_port     = 65535
     ip_protocol = "tcp"


### PR DESCRIPTION

<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

Please make sure that the PR fullfills these review criteria before submitting:

POSITIVES
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code
- Change has already been discussed and is known to committers (open an issue first otherwise)

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Adds a large amount of code
-->

## Change content and motivation
* Adds option to specify existing openstack network
* Extracts secgroup creation from network module to separate module

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
