### PR TITLE
Putting back travis_retry on kn apply

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ before_script:
 
 script:
   # Deploy
-  - kn apply
+  - travis_retry kn apply
   # Test
   - kn ansible-playbook /opt/KubeNow/playbooks/infra-test.yml
   - kn kubectl get nodes # try to list nodes


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please make sure to read the contributing guidelinse before you proceed: https://github.com/kubenow/KubeNow/blob/master/CONTRIBUTING.md. 
-->

## Change content and motivation
Putting back travis_retry on kn apply. IaaS failure are frequent, it is tedious to restart manually. Errors that are introduced by PRs should be ideally spotted before running the CI.

