### PR TITLE
Remove markup for "Fixes"

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Thanks for sending a Pull Request (PR)! Please make sure to read the contributin
 please list the issues that are going to be fixed by this PR (if applicable). 
 Use the suggested format to facilitate issue closing. 
 -->
-**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
+Fixes: <!-- fixes #X, fixes #Y, ... fixes #Z -->
 <!-- 
 please add documentation for your feature (if applicable), and link the documentation changes. 
 Documentation PRs are to be sent to https://github.com/kubenow/docs.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,4 @@ Fixes: <!-- fixes #X, fixes #Y, ... fixes #Z -->
 please add documentation for your feature (if applicable), and link the documentation changes. 
 Documentation PRs are to be sent to https://github.com/kubenow/docs.
 -->
-**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
+Docs: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->


### PR DESCRIPTION
When doing #312, I found another small issue with the PR template. When surrounding the `Fixes: ...` with bold stars, the Fixes link to the issue is destroyed.