### PR TITLE
Enable to specify provisioners image as an option

### DIFF
--- a/bin/kn
+++ b/bin/kn
@@ -108,18 +108,18 @@ fi
 # While current command starts with "-" parse options
 # in environment variables
 while [[ "$1" == -* ]]; do
-option="$1"
+  option="$1"
   case $option in
-      -i|--docker-image)
-      KN_PROVISIONERS_IMG="$2"
-      shift # past argument
-      shift # past value
-      ;;
-      *)
-      echo "unrecognized option $1" >&2
-      usage
-      exit 1
-      ;;
+  -i | --docker-image)
+    KN_PROVISIONERS_IMG="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  *)
+    echo "unrecognized option $1" >&2
+    usage
+    exit 1
+    ;;
   esac
 done
 

--- a/bin/kn
+++ b/bin/kn
@@ -110,7 +110,7 @@ fi
 while [[ "$1" == -* ]]; do
 option="$1"
   case $option in
-      -p|--provisioners)
+      -i|--docker-image)
       KN_PROVISIONERS_IMG="$2"
       shift # past argument
       shift # past value

--- a/bin/kn
+++ b/bin/kn
@@ -7,7 +7,6 @@ set -e # exit at first error
 ###############
 
 kubenow_version="master"
-provisioners_img="kubenow/provisioners:$kubenow_version"
 
 #############
 # Functions #
@@ -16,7 +15,8 @@ provisioners_img="kubenow/provisioners:$kubenow_version"
 function usage() {
   cat <<EOF
 
-Usage: kn <command>
+Usage: kn [options] <command>
+
 Commands:
 basic:
   help                   print this message
@@ -42,6 +42,10 @@ cloud providers CLI:
 developers:
   bash                   run an interactive bash promt in the provisioners container
   kubetoken              generate and print a kubeadm token
+
+Options:
+  -i, --docker-image <image>    specifies the provisioners docker image to be used.
+  KN_PROVISIONERS_IMG           Default: kubenow/provisioners:$kubenow_version
 
 EOF
 }
@@ -92,6 +96,33 @@ function validate_pwd() {
   fi
 }
 
+###########
+# Options #
+###########
+
+# Set defaults if not specified in the environment
+if [ -z "$KN_PROVISIONERS_IMG" ]; then
+  KN_PROVISIONERS_IMG="kubenow/provisioners:$kubenow_version"
+fi
+
+# While current command starts with "-" parse options
+# in environment variables
+while [[ "$1" == -* ]]; do
+option="$1"
+  case $option in
+      -p|--provisioners)
+      KN_PROVISIONERS_IMG="$2"
+      shift # past argument
+      shift # past value
+      ;;
+      *)
+      echo "unrecognized option $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
 ###############
 # Subcommands #
 ###############
@@ -133,33 +164,33 @@ init)
   fi
   # Init deployment
   mkdir -p "$init_dir"
-  docker_run "$provisioners_img" "$init_dir" "kn-init" "$host_cloud"
+  docker_run "$KN_PROVISIONERS_IMG" "$init_dir" "kn-init" "$host_cloud"
   ;;
 
 # Commands that do not need PWD validation
 az | openstack | gcloud | bash)
   # shellcheck disable=SC2068
-  docker_run "$provisioners_img" "$PWD" "$subcommand" ${@:2}
+  docker_run "$KN_PROVISIONERS_IMG" "$PWD" "$subcommand" ${@:2}
   ;;
 
 # Commands that need PWD validation
 terraform | ansible | ansible-playbook)
   validate_pwd
   # shellcheck disable=SC2068
-  docker_run "$provisioners_img" "$PWD" "$subcommand" ${@:2}
+  docker_run "$KN_PROVISIONERS_IMG" "$PWD" "$subcommand" ${@:2}
   ;;
 
 # KubeNow-defined commands that do no need PWD validation
 kubetoken)
   # shellcheck disable=SC2068
-  docker_run "$provisioners_img" "$PWD" "kn-$subcommand" ${@:2}
+  docker_run "$KN_PROVISIONERS_IMG" "$PWD" "kn-$subcommand" ${@:2}
   ;;
 
 # KubeNow-defined commands that need PWD validation
 apply | destroy | kubectl | helm | ssh)
   validate_pwd
   # shellcheck disable=SC2068
-  docker_run "$provisioners_img" "$PWD" "kn-$subcommand" ${@:2}
+  docker_run "$KN_PROVISIONERS_IMG" "$PWD" "kn-$subcommand" ${@:2}
   ;;
 
 "")


### PR DESCRIPTION
## Change content and motivation
Enable to specify provisioners image as an option. The code is structure such that in the future we can add more options. An idea would be to add every `KN_*` variable so it can be passed as an option as well.

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
