### PR TITLE
Added volumeoptions default setting

### DIFF
--- a/playbooks/roles/heketi-gluster/defaults/main.yml
+++ b/playbooks/roles/heketi-gluster/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+volumeoptions: |
+   "performance.quick-read off, performance.read-ahead off,
+   performance.io-cache off, performance.stat-prefetch off,
+   performance.low-prio-threads 32, network.remote-dio enable,
+   cluster.eager-lock enable, disperse.eager-lock enable,
+   cluster.quorum-type auto, cluster.server-quorum-type server,
+   cluster.data-self-heal-algorithm full, cluster.locking-scheme granular,
+   cluster.shd-max-threads 8, cluster.shd-wait-qlength 10000,
+   features.shard on, user.cifs off"

--- a/playbooks/roles/heketi-gluster/templates/object-store-sc.yml
+++ b/playbooks/roles/heketi-gluster/templates/object-store-sc.yml
@@ -10,7 +10,7 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   resturl: "http://{{ heketi_endpoint }}"
   volumetype: {{volumetype}}
-  volumeoptions: "stat-prefetch off, quick-read off, read-ahead off, io-cache off, remote-dio on, quorum-type auto, server-quorum-type server"
+  volumeoptions: {{volumeoptions}}
 mountOptions:
   - entry-timeout=0
   - attribute-timeout=0


### PR DESCRIPTION
This PR includes a new Ansible playbook to specify the default settings of the `object-store-sc`.