### PR TITLE
Reverted default SC settings

### DIFF
--- a/playbooks/roles/heketi-gluster/tasks/storage-creation.yml
+++ b/playbooks/roles/heketi-gluster/tasks/storage-creation.yml
@@ -73,7 +73,13 @@
     cluster.data-self-heal-algorithm full, cluster.locking-scheme granular,
     cluster.shd-max-threads 8, cluster.shd-wait-qlength 10000,
     features.shard on, user.cifs off{%- else %}
-    performance.io-cache off{% endif %}"
+    performance.quick-read off, performance.read-ahead off,
+    performance.io-cache off, performance.stat-prefetch off,
+    performance.low-prio-threads 32, network.remote-dio enable,
+    cluster.eager-lock enable, disperse.eager-lock enable,
+    cluster.quorum-type auto, cluster.server-quorum-type server,
+    cluster.data-self-heal-algorithm full, cluster.locking-scheme granular,
+    cluster.shd-wait-qlength 10000, features.shard on, user.cifs off{% endif %}"
 
 - name: render storage-class
   template:

--- a/playbooks/roles/heketi-gluster/templates/storage-class.yml
+++ b/playbooks/roles/heketi-gluster/templates/storage-class.yml
@@ -10,4 +10,3 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   resturl: "http://{{ heketi_endpoint }}"
   volumetype: {{volumetype}}
-  volumeoptions: {{volumeoptions}}


### PR DESCRIPTION
Last change by @andersla broke Pachyderm deployments with one or 2 Gluster nodes.

This PR reverts the default SC settings for GlusterFS and fixed volumeoptions for `object-store-sc`