### PR TITLE
Tune Slack notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -210,6 +210,8 @@ jobs:
 notifications:
   email: false
   slack:
+    on_success: change 
+    on_failure: always
     secure: >
       ed+rC8Oc4EdZfptHGX1Xr5sNc+wQTyjb4rjJT0P/U/NBStmik7dnUfAK9vk6XYVDrrPZxmAz6A
       cJmEaxY4kdG2HBLBPD0keRxKh2rN2ZbjCTWuGlAomMkmNDcyeVoQI95HcT0nYHzgoUCGn7lgZ7

--- a/.travis.yml
+++ b/.travis.yml
@@ -210,7 +210,7 @@ jobs:
 notifications:
   email: false
   slack:
-    on_success: change 
+    on_success: change
     on_failure: always
     secure: >
       ed+rC8Oc4EdZfptHGX1Xr5sNc+wQTyjb4rjJT0P/U/NBStmik7dnUfAK9vk6XYVDrrPZxmAz6A


### PR DESCRIPTION
## Change content and motivation
Tuning Slack notification, so that we get notified only on failure (and if the build status changes).

