### PR TITLE
 Azure alternative boot image and some other things (1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,11 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Install json2hcl
+RUN curl -L "https://github.com/kvz/json2hcl/releases/download/v0.0.6/json2hcl_v0.0.6_linux_amd64" > \
+    "/bin/json2hcl" && \
+    chmod a+rx /bin/json2hcl
+
 # Install Terraform
 RUN curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" > \
     "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 <span class="badge-slack"><a href="https://kubenow-slackin.herokuapp.com" title="Invite yourself to our Slack team"><img src="https://kubenow-slackin.herokuapp.com/badge.svg" alt="Slackin button"/></a></span>
 <span class="badge-patreon"><a href="https://patreon.com/kubenow" title="Donate to this project using Patreon"><img src="https://img.shields.io/badge/patreon-donate-yellow.svg" alt="Patreon donate button" /></a></span>
 
-
 KubeNow is a cloud agnostic platform for microservices, based on Docker and Kubernetes. Other than lighting-fast Kubernetes operations, KubeNow helps you in lifting your final application configuring DNS records and distributed storage. Once you have defined your application as a Helm package, lifting it is as simple as:
 
 ```bash

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -1,10 +1,14 @@
 # Cluster settings
 variable cluster_prefix {}
 
+# This var is for KubeNow boot image version
+# leave empty if public image is specified
 variable boot_image {
   default = ""
 }
 
+# This var is for any Azure boot image
+# leave empty if KubeNow image is specified
 variable boot_image_public {
   type = "map"
 
@@ -133,6 +137,7 @@ provider "azurerm" {
 # Data-lookup, subscriptin_id etc.
 data "azurerm_client_config" "current" {}
 
+# This is for KubeNow boot image only
 # Generates image resource group name by adding location as suffix (without spaces)
 data "null_data_source" "image_rg" {
   inputs = {
@@ -140,13 +145,16 @@ data "null_data_source" "image_rg" {
   }
 }
 
-# Generates image resource group name by adding location as suffix (without spaces)
+# This is for KubeNow boot image only
+# Generates KubeNow image_id
 data "null_data_source" "private_img" {
   inputs = {
     image_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${data.null_data_source.image_rg.inputs.name}/providers/Microsoft.Compute/images/${var.boot_image}"
   }
 }
 
+# This is for KubeNow boot image only
+# Sets image_id to KubeNow image id if KubeNow image is specified otherwise ""
 data "null_data_source" "boot_image_private_id_lookup" {
   inputs = {
     image_id = "${var.boot_image == "" ? "" : data.null_data_source.private_img.inputs.image_id}"

--- a/azure/node-extra-disk/main.tf
+++ b/azure/node-extra-disk/main.tf
@@ -5,7 +5,11 @@ variable name_prefix {}
 variable resource_group_name {}
 variable location {}
 variable vm_size {}
-variable image_id {}
+variable boot_image_private_id {}
+
+variable boot_image_public {
+  type = "map"
+}
 
 # SSH settings
 variable ssh_user {}
@@ -108,7 +112,11 @@ resource "azurerm_virtual_machine" "vm" {
   network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
 
   storage_image_reference {
-    id = "${var.image_id}"
+    id        = "${var.boot_image_private_id}"
+    publisher = "${var.boot_image_public["publisher"]}"
+    offer     = "${var.boot_image_public["offer"]}"
+    sku       = "${var.boot_image_public["sku"]}"
+    version   = "${var.boot_image_public["version"]}"
   }
 
   storage_os_disk {

--- a/azure/node-extra-disk/main.tf
+++ b/azure/node-extra-disk/main.tf
@@ -5,8 +5,13 @@ variable name_prefix {}
 variable resource_group_name {}
 variable location {}
 variable vm_size {}
+
+# This var is for KubeNow boot image version
+# will be empty if public image is specified
 variable boot_image_private_id {}
 
+# This var is for any Azure boot image
+# will be empty if KubeNow image is specified
 variable boot_image_public {
   type = "map"
 }
@@ -111,6 +116,8 @@ resource "azurerm_virtual_machine" "vm" {
   vm_size               = "${var.vm_size}"
   network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
 
+  # if id specified, other params will be empty
+  # if id is not specified, other params will be set
   storage_image_reference {
     id        = "${var.boot_image_private_id}"
     publisher = "${var.boot_image_public["publisher"]}"

--- a/azure/node/main.tf
+++ b/azure/node/main.tf
@@ -5,7 +5,11 @@ variable name_prefix {}
 variable resource_group_name {}
 variable location {}
 variable vm_size {}
-variable image_id {}
+variable boot_image_private_id {}
+
+variable boot_image_public {
+  type = "map"
+}
 
 # SSH settings
 variable ssh_user {}
@@ -95,7 +99,11 @@ resource "azurerm_virtual_machine" "vm" {
   network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
 
   storage_image_reference {
-    id = "${var.image_id}"
+    id        = "${var.boot_image_private_id}"
+    publisher = "${var.boot_image_public["publisher"]}"
+    offer     = "${var.boot_image_public["offer"]}"
+    sku       = "${var.boot_image_public["sku"]}"
+    version   = "${var.boot_image_public["version"]}"
   }
 
   storage_os_disk {

--- a/azure/node/main.tf
+++ b/azure/node/main.tf
@@ -5,8 +5,13 @@ variable name_prefix {}
 variable resource_group_name {}
 variable location {}
 variable vm_size {}
+
+# This var is for KubeNow boot image version
+# will be empty if public image is specified
 variable boot_image_private_id {}
 
+# This var is for any Azure boot image
+# will be empty if KubeNow image is specified
 variable boot_image_public {
   type = "map"
 }
@@ -98,6 +103,8 @@ resource "azurerm_virtual_machine" "vm" {
   vm_size               = "${var.vm_size}"
   network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
 
+  # if id specified, other params will be empty
+  # if id is not specified, other params will be set
   storage_image_reference {
     id        = "${var.boot_image_private_id}"
     publisher = "${var.boot_image_public["publisher"]}"

--- a/bin/kn
+++ b/bin/kn
@@ -75,7 +75,7 @@ function docker_run() {
     --env-file <(env | grep GOOGLE_) \
     --env-file <(env | grep AWS_) \
     --env-file <(env | grep ARM_) \
-    --env-file <(env | grep KUBENOW_) \
+    --env-file <(env | grep KN_) \
     "$container" \
     "/opt/KubeNow/bin/docker-entrypoint" ${@:3}
 }

--- a/bin/kn-apply
+++ b/bin/kn-apply
@@ -3,13 +3,13 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-host_cloud=$(grep -w "provider" config.tfvars |
-  cut -d "=" -f 2- |
-  awk -F\" '{print $(NF-1)}')
 
-image_name=$(grep -w "boot_image" config.tfvars |
-  cut -d "=" -f 2- |
-  awk -F\" '{print $(NF-1)}')
+# Read config file into variable as as json
+kn_config=$(json2hcl -reverse <config.tfvars)
+
+# Set variables from json-config
+host_cloud=$(jq -r '.provider' <<<"$kn_config")
+image_name=$(jq -r '.boot_image' <<<"$kn_config")
 
 # Check for recognized cloud provider
 if ! grep -qw "$host_cloud" <<<"openstack gce azure aws"; then

--- a/bin/kn-apply
+++ b/bin/kn-apply
@@ -3,7 +3,6 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-
 # Read config file into variable as as json
 kn_config=$(json2hcl -reverse <config.tfvars)
 

--- a/bin/kn-destroy
+++ b/bin/kn-destroy
@@ -3,9 +3,14 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-host_cloud=$(grep -w "provider" config.tfvars |
-  cut -d "=" -f 2- |
-  awk -F\" '{print $(NF-1)}')
+# Run pre-destroy hook
+/KubeNow_root/bin/pre-destroy
+
+# Read config file into variable as as json
+kn_config=$(json2hcl -reverse <config.tfvars)
+
+# Set variables from json-config
+host_cloud=$(jq -r '.provider' <<<"$kn_config")
 
 # Check for recognized cloud provider
 if ! grep -qw "$host_cloud" <<<"openstack gce azure aws"; then

--- a/common/inventory/main.tf
+++ b/common/inventory/main.tf
@@ -78,9 +78,9 @@ locals {
   edge_private_ip = "${split(",", length(var.edge_private_ip) == 0 ? join(",", list("")) : join(",", var.edge_private_ip))}"
 
   # Format list of different node types
-  masters    = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s", local.master_hostnames , local.master_public_ip, var.ssh_user ))}"
-  nodes      = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s", local.node_hostnames , local.node_public_ip, var.ssh_user))}"
-  pure_edges = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s", local.edge_hostnames , local.edge_public_ip, var.ssh_user))}"
+  masters    = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s private_ip=%s", local.master_hostnames, local.master_public_ip, var.ssh_user, local.master_private_ip ))}"
+  nodes      = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s private_ip=%s", local.node_hostnames,   local.node_public_ip,   var.ssh_user, local.node_private_ip   ))}"
+  pure_edges = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s private_ip=%s", local.edge_hostnames,   local.edge_public_ip,   var.ssh_user, local.edge_private_ip   ))}"
 
   # Add master to edges if that is the case
   edges = "${var.master_as_edge == true ? "${format("%s\n%s", local.masters, local.pure_edges)}" : local.pure_edges}"

--- a/common/inventory/main.tf
+++ b/common/inventory/main.tf
@@ -78,9 +78,9 @@ locals {
   edge_private_ip = "${split(",", length(var.edge_private_ip) == 0 ? join(",", list("")) : join(",", var.edge_private_ip))}"
 
   # Format list of different node types
-  masters    = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s private_ip=%s", local.master_hostnames, local.master_public_ip, var.ssh_user, local.master_private_ip ))}"
-  nodes      = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s private_ip=%s", local.node_hostnames,   local.node_public_ip,   var.ssh_user, local.node_private_ip   ))}"
-  pure_edges = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s private_ip=%s", local.edge_hostnames,   local.edge_public_ip,   var.ssh_user, local.edge_private_ip   ))}"
+  masters    = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s", local.master_hostnames , local.master_public_ip, var.ssh_user ))}"
+  nodes      = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s", local.node_hostnames , local.node_public_ip, var.ssh_user))}"
+  pure_edges = "${join("\n",formatlist("%s ansible_host=%s ansible_user=%s", local.edge_hostnames , local.edge_public_ip, var.ssh_user))}"
 
   # Add master to edges if that is the case
   edges = "${var.master_as_edge == true ? "${format("%s\n%s", local.masters, local.pure_edges)}" : local.pure_edges}"


### PR DESCRIPTION
# Change content and motivation

Allows for alternative boot image for Azure (not only KubeNow image)
Fixes download status message in Azure image import script
Changes KubeNow_ env prefix to KN_
Adds hcl2json (HashicorpConfigLanguage2json) to Dockerimage and changes reading of parameters in config file from sed with grep to hcl2json tool

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
Fixes #316
Fixes #327
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
