### PR TITLE
Allow for https backend traefic within cluster without certificates

### DIFF
--- a/playbooks/roles/traefik/files/traefik.toml
+++ b/playbooks/roles/traefik/files/traefik.toml
@@ -2,6 +2,9 @@
 # Defaults
 ################################################################
 defaultEntryPoints = ["http","https"]
+# InsecureSkipVerify : If set to true invalid SSL certificates are accepted for backends.
+# Note: This disables detection of man-in-the-middle attacks so should only be used on secure backend networks.
+insecureSkipVerify = true
 ################################################################
 # Web configuration backend
 ################################################################


### PR DESCRIPTION
## Change content and motivation

Allow for https backend traefic within cluster without certificates. Kubernetes Dashboard helm chart is now only serving internal traffic as https and internal handshake fails if traefik tries to forward traffic without valid certs.

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
