### PR TITLE
Revert erroneous call to pre-destroy hook

### DIFF
--- a/bin/kn-destroy
+++ b/bin/kn-destroy
@@ -3,9 +3,6 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-# Run pre-destroy hook
-/KubeNow_root/bin/pre-destroy
-
 # Read config file into variable as as json
 kn_config=$(json2hcl -reverse <config.tfvars)
 


### PR DESCRIPTION
Revert erroneous call to pre-destroy hook - since it is not supposed to be in master

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
fixes #393 
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
