### PR TITLE
Disable swap that might have been automatically enabled by cloud-vm-flavor

### DIFF
--- a/bootstrap/bootstrap-default.sh
+++ b/bootstrap/bootstrap-default.sh
@@ -32,6 +32,11 @@ systemctl restart kubelet
 echo "Modprobe dm_thin_pool..."
 modprobe dm_thin_pool
 
+# make sure swap is off
+sudo swapoff -a
+# make sure swap is removed from fstab
+sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+
 # Execute kubeadm init vs. kubeadm join depending on node type
 if [[ "$node_labels" == *"role=master"* ]]; then
   echo "Inititializing the master...."

--- a/bootstrap/bootstrap-default.sh
+++ b/bootstrap/bootstrap-default.sh
@@ -34,8 +34,8 @@ modprobe dm_thin_pool
 
 # make sure swap is off
 sudo swapoff -a
-# make sure swap is removed from fstab
-sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+# make sure any line with swap is removed from fstab
+sudo sed -i '/swap/d' /etc/fstab
 
 # Execute kubeadm init vs. kubeadm join depending on node type
 if [[ "$node_labels" == *"role=master"* ]]; then


### PR DESCRIPTION
## Change content and motivation

Disable swap in bootstrap script since some OS-flavors automatically will add swap and this is not allowed by Kubernetes

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
