### PR TITLE
Fix parameter names used in Ansible pvc-playbook

### DIFF
--- a/playbooks/roles/pvc/tasks/main.yml
+++ b/playbooks/roles/pvc/tasks/main.yml
@@ -4,12 +4,12 @@
     path: ~/.kubernetes-yaml/pvc/
     state: directory
     mode: 0755
-- name: template {{name}}-pvc
+- name: template {{claim_name}}-pvc
   template:
     src: template-pvc.yml.tpl
-    dest: "~/.kubernetes-yaml/pvc/pvc-{{name}}.yml"
+    dest: "~/.kubernetes-yaml/pvc/pvc-{{claim_name}}.yml"
 
-- name: create {{name}}-pvc
+- name: create {{claim_name}}-pvc
   command: >
     kubectl apply -f
-    $HOME/.kubernetes-yaml/pvc/pvc-{{name}}.yml
+    $HOME/.kubernetes-yaml/pvc/pvc-{{claim_name}}.yml

--- a/playbooks/roles/pvc/templates/template-pvc.yml.tpl
+++ b/playbooks/roles/pvc/templates/template-pvc.yml.tpl
@@ -2,7 +2,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{name}}
+  name: {{claim_name}}
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION

## Change content and motivation

Fix parameter names used in Ansible playbook because 'name' is raising ansible warning

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
