### PR TITLE
Add nginx as ingress option

### DIFF
--- a/playbooks/install-core.yml
+++ b/playbooks/install-core.yml
@@ -7,4 +7,5 @@
     - {role: wait-kube-dns, tags: ['minimal']}
     - {role: start-helm, tags: ['minimal']}
     - {role: traefik, tags: ['traefik'], when: ingress_controller is undefined or (ingress_controller is defined and ingress_controller == "traefik")}
+    - {role: nginx, tags: ['nginx'], when: ingress_controller is defined and ingress_controller == "nginx"}
     - {role: heketi-gluster, tags: ['heketi-glusterfs'], when: glusternode_count is defined and glusternode_count > 0}

--- a/playbooks/roles/nginx/tasks/main.yaml
+++ b/playbooks/roles/nginx/tasks/main.yaml
@@ -1,0 +1,8 @@
+- name: copy helm yaml template for nginx
+  template:
+    src: nginx-config.yaml
+    dest: /tmp/nginx-config.yaml
+
+- name: install nginx
+  command: >
+    helm install --name nginx-ingress --namespace=nginx-ingress stable/nginx-ingress --values /tmp/nginx-config.yml

--- a/playbooks/roles/nginx/tasks/main.yaml
+++ b/playbooks/roles/nginx/tasks/main.yaml
@@ -5,4 +5,4 @@
 
 - name: install nginx
   command: >
-    helm install --name nginx-ingress --namespace=nginx-ingress stable/nginx-ingress --values /tmp/nginx-config.yml
+    helm upgrade --install nginx-ingress --namespace=nginx-ingress stable/nginx-ingress --values /tmp/nginx-config.yml

--- a/playbooks/roles/nginx/templates/nginx-config.yaml
+++ b/playbooks/roles/nginx/templates/nginx-config.yaml
@@ -1,0 +1,13 @@
+controller:
+  nodeSelector:
+    role: edge
+  hostNetwork: true
+  kind: DaemonSet
+  service:
+    type: NodePort
+  stats:
+    enabled: false
+  metrics:
+    enabled: false
+
+tcp:

--- a/templates/config.tfvars.openstack-template
+++ b/templates/config.tfvars.openstack-template
@@ -39,6 +39,11 @@ provision = {
   "action" = {
     "type"       = "ansible-playbook"
     "playbook"   = "playbooks/install-core.yml"
+    "extra_vars" = {
+      # To disable traefik in favor for an external ingress controller replace "traefik" with "none".
+      # To use nginx instead of traefik replace "traefik" with "nginx" on the line below.
+      "ingress_controller" = "traefik"
+    }
   }
 }
 


### PR DESCRIPTION
## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->
This adds the option to use nginx as ingress controller in an OpenStack environment. The benefits are that the user are not limited to ingress on port 80/443 and adds the ability to handle non HTTP/S traffic.

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
Documentation writeup is in progress.
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
