### PR TITLE
Ingress: allow nginx to be started on the master node

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yaml
+++ b/playbooks/roles/nginx/tasks/main.yaml
@@ -5,4 +5,4 @@
 
 - name: install nginx
   command: >
-    helm upgrade --install nginx-ingress --namespace=nginx-ingress stable/nginx-ingress --values /tmp/nginx-config.yml
+    helm upgrade --install nginx-ingress --namespace=nginx-ingress stable/nginx-ingress --values /tmp/nginx-config.yaml

--- a/playbooks/roles/nginx/templates/nginx-config.yaml
+++ b/playbooks/roles/nginx/templates/nginx-config.yaml
@@ -1,4 +1,7 @@
 controller:
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
   nodeSelector:
     role: edge
   hostNetwork: true


### PR DESCRIPTION
## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->
At the stage when the nginx ingress controller is stared, we need to specifically allow it to be started on the mater node.
<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
