### PR TITLE
Bump traefik from 1.3.8 to 1.7.4

### DIFF
--- a/playbooks/roles/traefik/files/traefik-daemonset.yml
+++ b/playbooks/roles/traefik/files/traefik-daemonset.yml
@@ -20,7 +20,7 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:
-      - image: traefik:v1.3.8
+      - image: traefik:v1.7.4
         name: traefik-ingress-lb
         imagePullPolicy: Always
         volumeMounts:


### PR DESCRIPTION
Hi, it seems that traefik-1.3.8 can not handle `traefik.ingress.kubernetes.io/affinity: "true"`,
this was fixed when I upgraded to 1.7.4 Caveat: I haven't tested any of the other traefik 
features we are using. Yours, Steffen

## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
