### PR TITLE
In openstack check already cached image first

### DIFF
--- a/bin/image-create-openstack.sh
+++ b/bin/image-create-openstack.sh
@@ -38,17 +38,32 @@ fi
 
 # If it doesn't exist then download it
 echo "Image not present in OpenStack"
-echo "Downloading image to local /tmp/"
-curl "$KN_IMAGE_BUCKET_URL/$file_name" \
-  -o "/tmp/$file_name" \
-  --connect-timeout 30 \
-  --max-time 1800
 
 echo "Download md5 sum file"
 curl "$KN_IMAGE_BUCKET_URL/$file_name.md5" \
   -o "/tmp/$file_name.md5" \
   --connect-timeout 30 \
   --max-time 1800
+
+if [ -f "/tmp/$file_name" ]; then
+  echo "Check md5 sum on already downloaded file"
+  md5result=$(
+    cd /tmp
+    md5sum -c "$file_name.md5"
+  )
+  if [[ "$md5result" != *": OK"* ]]; then
+    echo "Cached file failed md5 sum, will clear cache"
+    rm "/tmp/$file_name"
+  fi
+fi
+
+if [ ! -f "/tmp/$file_name" ];
+  echo "Downloading image to local /tmp/"
+  curl "$KN_IMAGE_BUCKET_URL/$file_name" \
+    -o "/tmp/$file_name" \
+    --connect-timeout 30 \
+    --max-time 1800
+fi
 
 # Verify md5sum of downloaded file
 echo "Check md5 sum"


### PR DESCRIPTION
## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->

If the base image don't exists in the openstack cloud, kubenow tries to download it from amazon and saves it to the local `/tmp` directory. This pull request implements a feature where the existance of that file is checked before downloading it. Saving time in case the user has already downloaded the file. The checksum file is still always downloaded.

<!-- Please uncomment if applicable -->
<!-- ## GitHub cross-links -->
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
