### PR TITLE
Enable etcd encryption

### DIFF
--- a/playbooks/install-core.yml
+++ b/playbooks/install-core.yml
@@ -8,4 +8,5 @@
     - {role: start-helm, tags: ['minimal']}
     - {role: traefik, tags: ['traefik'], when: ingress_controller is undefined or (ingress_controller is defined and ingress_controller == "traefik")}
     - {role: nginx, tags: ['nginx'], when: ingress_controller is defined and ingress_controller == "nginx"}
+    - {role: encrypt-etcd, tags: ['encrypt-etcd'], when encrypt_etcd is defined and encrypt_etcd == "true"}
     - {role: heketi-gluster, tags: ['heketi-glusterfs'], when: glusternode_count is defined and glusternode_count > 0}

--- a/playbooks/roles/encrypt-etcd/tasks/main.yaml
+++ b/playbooks/roles/encrypt-etcd/tasks/main.yaml
@@ -1,0 +1,40 @@
+---
+- name: generate encryption key
+  shell: head -c 32 /dev/urandom | base64 -
+  register: key
+  run_once: true
+
+- name: copy secrets conf file
+  become: yes
+  template:
+    src: secrets.conf
+    dest: /etc/kubernetes/pki/etcd/secrets.conf
+
+- name: insert key into secrets.conf
+  become: yes
+  replace:
+    path: /etc/kubernetes/pki/etcd/secrets.conf
+    regexp: "ENCRYPTION_KEY"
+    replace: "{{key.stdout}}"
+
+- name: update kube-api server to use encryption
+  become: yes
+  lineinfile:
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    regexp: '--enable-bootstrap-token-auth=true'
+    insertafter: '--enable-bootstrap-token-auth=true$'
+    line: '    - --encryption-provider-config=/etc/kubernetes/pki/etcd/secrets.conf'
+
+- name: wait until api-server is back online
+  shell: kubectl -n kube-system get pod -l component=kube-apiserver | grep -o 'Running' | wc -l
+  register: api_ready
+  until: (api_ready.stdout | int) > 0
+  # Wait for 5 minutes
+  retries: 60
+  delay: 5
+
+- name: make sure that all secrets are encrypted
+  shell: kubectl get secrets --all-namespaces -o json | kubectl replace -f -
+
+- name: make sure that all configmaps are encrypted
+  shell: kubectl get cm --all-namespaces -o json | kubectl replace -f -

--- a/playbooks/roles/encrypt-etcd/templates/secrets.conf
+++ b/playbooks/roles/encrypt-etcd/templates/secrets.conf
@@ -1,0 +1,12 @@
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
+resources:
+  - resources:
+    - secrets
+    - configmaps
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: ENCRYPTION_KEY
+    - identity: {}

--- a/templates/config.tfvars.openstack-template
+++ b/templates/config.tfvars.openstack-template
@@ -43,6 +43,8 @@ provision = {
       # To disable traefik in favor for an external ingress controller replace "traefik" with "none".
       # To use nginx instead of traefik replace "traefik" with "nginx" on the line below.
       "ingress_controller" = "traefik"
+      # To enable encryption of the etcd key value store, change the value to "true" on the line below.
+      "encrypt_etcd" = "false"
     }
   }
 }


### PR DESCRIPTION
## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->
As of kubernetes 1.13 encryption of of secrets at rest is considered a stable feture. This enables the user to optionally enable encryption of the etcd datastore. The encryption key is automatically generated during deployment.
<!-- Please uncomment if applicable -->
 ## GitHub cross-links 
#436 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
<!-- Fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
<!-- Docs: kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
