### PR TITLE
change to new cloudflare 2.0 API with api_token and zone_id

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -106,6 +106,10 @@ variable cloudflare_subdomain {
   default = ""
 }
 
+variable cloudflare_zone_id {
+  default = ""
+}
+
 variable cloudflare_proxied {
   default = "false"
 }
@@ -296,6 +300,7 @@ module "cloudflare" {
   cloudflare_token     = "${var.cloudflare_token}"
   cloudflare_domain    = "${var.cloudflare_domain}"
   cloudflare_subdomain = "${var.cloudflare_subdomain}"
+  cloudflare_zone_id   = "${var.cloudflare_zone_id}"
 
   # add optional subdomain to record names
   # terraform interpolation is limited and can not return list in conditionals, workaround: first join to string, then split

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -90,6 +90,10 @@ variable cloudflare_subdomain {
   default = ""
 }
 
+variable cloudflare_zone_id {
+  default = ""
+}
+
 variable cloudflare_proxied {
   default = "false"
 }
@@ -261,6 +265,7 @@ module "cloudflare" {
   cloudflare_token     = "${var.cloudflare_token}"
   cloudflare_domain    = "${var.cloudflare_domain}"
   cloudflare_subdomain = "${var.cloudflare_subdomain}"
+  cloudflare_zone_id   = "${var.cloudflare_zone_id}"
 
   # add optional subdomain to record names
   # terraform interpolation is limited and can not return list in conditionals, workaround: first join to string, then split

--- a/common/cloudflare/main.tf
+++ b/common/cloudflare/main.tf
@@ -2,6 +2,7 @@ variable cloudflare_email {}
 variable cloudflare_token {}
 variable cloudflare_domain {}
 variable cloudflare_subdomain {}
+variable cloudflare_zone_id {}
 
 variable record_count {
   default = 0
@@ -19,16 +20,16 @@ variable proxied {}
 
 # Configure the Cloudflare provider
 provider "cloudflare" {
-  version = "~> 1.0"
+  version = "~> 2.0"
   email   = "${ var.cloudflare_email }"
-  token   = "${ var.cloudflare_token }"
+  api_token   = "${ var.cloudflare_token }"
 }
 
 # record_count is length(var.record_names) * length(var.iplist)
 # with the arithmetic of / and % records with all combinations of var.iplist and var.record_names will be created
 resource "cloudflare_record" "rec" {
   count   = "${ var.record_count }"
-  domain  = "${ var.cloudflare_domain }"
+  zone_id = "${ var.cloudflare_zone_id }"
   value   = "${ element(var.iplist, count.index / length(var.record_names) ) }"
   name    = "${ element(var.record_names, count.index % length(var.record_names) ) }"
   type    = "A"

--- a/gce/main.tf
+++ b/gce/main.tf
@@ -95,6 +95,10 @@ variable cloudflare_subdomain {
   default = ""
 }
 
+variable cloudflare_zone_id {
+  default = ""
+}
+
 variable cloudflare_proxied {
   default = "false"
 }
@@ -238,6 +242,7 @@ module "cloudflare" {
   cloudflare_token     = "${var.cloudflare_token}"
   cloudflare_domain    = "${var.cloudflare_domain}"
   cloudflare_subdomain = "${var.cloudflare_subdomain}"
+  cloudflare_zone_id   = "${var.cloudflare_zone_id}"
 
   # add optional subdomain to record names
   # terraform interpolation is limited and can not return list in conditionals, workaround: first join to string, then split

--- a/kvm/main.tf
+++ b/kvm/main.tf
@@ -60,6 +60,10 @@ variable cloudflare_subdomain {
   default = ""
 }
 
+variable cloudflare_zone_id {
+  default = ""
+}
+
 variable cloudflare_proxied {
   default = "false"
 }
@@ -213,6 +217,7 @@ module "cloudflare" {
   cloudflare_token     = "${var.cloudflare_token}"
   cloudflare_domain    = "${var.cloudflare_domain}"
   cloudflare_subdomain = "${var.cloudflare_subdomain}"
+  cloudflare_zone_id   = "${var.cloudflare_zone_id}"
 
   # add optional subdomain to record names
   # terraform interpolation is limited and can not return list in conditionals, workaround: first join to string, then split

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -111,6 +111,10 @@ variable cloudflare_subdomain {
   default = ""
 }
 
+variable cloudflare_zone_id {
+  default = ""
+}
+
 variable cloudflare_proxied {
   default = "false"
 }
@@ -285,6 +289,7 @@ module "cloudflare" {
   cloudflare_token     = "${var.cloudflare_token}"
   cloudflare_domain    = "${var.cloudflare_domain}"
   cloudflare_subdomain = "${var.cloudflare_subdomain}"
+  cloudflare_zone_id   = "${var.cloudflare_zone_id}"
 
   # add optional subdomain to record names
   # terraform interpolation is limited and can not return list in conditionals, workaround: first join to string, then split


### PR DESCRIPTION
## Change content and motivation
This adds the changes for the Terraform Cloudflare 2.X provider. 

## GitHub cross-links
This KubeNow is probably used as part of
https://github.com/phnmnl/cloud-deploy-kubenow-dalcotidine-20190625/pull/4

Docs: https://github.com/kubenow/docs/pull/40

Yours, Steffen